### PR TITLE
Enhance developer onboarding and API catalog

### DIFF
--- a/tools-api/app/main.py
+++ b/tools-api/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
-from app.routers import parser, docx
+from app.routers import parser, docx, gdocs_parser
 from app.extensions import local_queue_extension
 from app.utils.logger import logger
 from app.config import settings
@@ -47,6 +47,7 @@ async def log_requests(request: Request, call_next):
 # Routers
 app.include_router(parser.router, prefix="/parse", tags=["parser"])
 app.include_router(docx.router)  # Already has /docx prefix
+app.include_router(gdocs_parser.router)
 local_queue_extension.register(app)
 
 

--- a/tools-api/app/runtime/documentation.py
+++ b/tools-api/app/runtime/documentation.py
@@ -1,55 +1,173 @@
 """Utility helpers for displaying Tools API documentation snippets."""
 from __future__ import annotations
 
+import json
 from contextlib import asynccontextmanager
-from typing import AsyncIterator, Iterable
+from pathlib import Path
+from typing import Any, AsyncIterator, Dict, Iterable, Iterator, List, Optional
 
 from fastapi import FastAPI
+
+try:  # pragma: no cover - guarded import for environments without PyYAML
+    import yaml
+except Exception:  # pragma: no cover - fallback if PyYAML is missing
+    yaml = None  # type: ignore
+
+
+CATALOG_PATH = Path(__file__).resolve().parents[2] / "docs" / "service_catalog.yaml"
+
+
+def _pretty_json(data: Any) -> str:
+    """Return JSON formatted text for examples."""
+
+    if data is None:
+        return "null"
+    return json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False)
+
+
+def _load_catalog() -> Dict[str, Any]:
+    """Load the service catalog YAML file into a dictionary."""
+
+    if yaml is None:
+        return {
+            "error": "PyYAML is not installed. Install it or update requirements.txt to enable the service catalog printer.",
+        }
+
+    if not CATALOG_PATH.exists():
+        return {
+            "error": f"Service catalog not found at {CATALOG_PATH}. Create the file or update code_flow.md instructions.",
+        }
+
+    try:
+        contents = CATALOG_PATH.read_text(encoding="utf-8")
+        catalog = yaml.safe_load(contents)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        return {"error": f"Failed to parse service catalog: {exc}"}
+
+    if not isinstance(catalog, dict):
+        return {"error": "Service catalog must be a mapping with a 'services' key."}
+    return catalog
+
+
+def _format_fields(fields: Dict[str, str]) -> Iterator[str]:
+    for name, description in fields.items():
+        yield f"         • {name}: {description}"
+
+
+def _format_endpoint(endpoint: Dict[str, Any]) -> Iterator[str]:
+    method = str(endpoint.get("method", "GET")).upper()
+    path = endpoint.get("path", "/")
+    description = endpoint.get("description")
+    yield f"   {method} {path}"
+    if description:
+        yield f"      {description}"
+
+    request_spec: Optional[Dict[str, Any]] = endpoint.get("request")
+    if request_spec:
+        content_type = request_spec.get("content_type")
+        model = request_spec.get("model")
+        if content_type or model:
+            ct = f" ({content_type})" if content_type else ""
+            model_text = f" — {model}" if model else ""
+            yield f"      Request{ct}{model_text}"
+        fields = request_spec.get("fields")
+        if isinstance(fields, dict) and fields:
+            yield "      Fields:"
+            yield from _format_fields(fields)
+        example = request_spec.get("example")
+        if example is not None:
+            yield "      Example Request:"
+            for line in _pretty_json(example).splitlines():
+                yield f"         {line}"
+
+    response_spec: Optional[Dict[str, Any]] = endpoint.get("response")
+    if response_spec:
+        content_type = response_spec.get("content_type")
+        model = response_spec.get("model")
+        if content_type or model:
+            ct = f" ({content_type})" if content_type else ""
+            model_text = f" — {model}" if model else ""
+            yield f"      Response{ct}{model_text}"
+        fields = response_spec.get("fields")
+        if isinstance(fields, dict) and fields:
+            yield "      Fields:"
+            yield from _format_fields(fields)
+        example = response_spec.get("example")
+        if example is not None:
+            yield "      Example Response:"
+            for line in _pretty_json(example).splitlines():
+                yield f"         {line}"
+
+    notes: Optional[List[str]] = endpoint.get("notes")
+    if notes:
+        yield "      Notes:"
+        for note in notes:
+            yield f"         - {note}"
+
+
+def _format_service(service: Dict[str, Any]) -> Iterator[str]:
+    name = service.get("name", "Unnamed Service")
+    summary = service.get("summary")
+    docs_url = service.get("docs_url")
+
+    yield name
+    if summary:
+        yield f"  {summary}"
+    if docs_url:
+        yield f"  Docs UI: {docs_url}"
+
+    endpoints = service.get("endpoints", [])
+    for endpoint in endpoints:
+        yield from _format_endpoint(endpoint)
 
 
 def _documentation_lines() -> Iterable[str]:
     """Yield formatted lines that describe the public API surface."""
-    yield "\nAPI Documentation:"
+
+    catalog = _load_catalog()
+    error = catalog.get("error") if isinstance(catalog, dict) else None
+
+    yield "\nTools API — Service Catalog"
     yield "=" * 50
-    yield "\n1. Convert HTML to Google Docs format:"
-    yield "   POST http://localhost:8000/parse/html"
-    yield '   {"html": "<h1>Hello World</h1>"}'
 
-    yield "\n2. Parse Google Docs JSON to text:"
-    yield "   POST http://localhost:8000/parse/gdocs/json"
-    yield "   Content: Google Docs JSON structure"
-    yield "\n   Example response:"
-    yield "   {"
-    yield '     "metadata": {"title": "Example Document"},'
-    yield "     \"content\": {"
-    yield '       "text": "Hello world",'
-    yield '       "urls": ["https://example.com"],'
-    yield '       "images": ["https://example.com/image.jpg"]'
-    yield "     }"
-    yield "   }"
+    if error:
+        yield f"\n⚠️  {error}"
+        yield "\nSee docs/service_catalog.yaml for the canonical API list."
+        yield "=" * 50
+        return
 
-    yield "\n3. Parse Google Docs file:"
-    yield "   POST http://localhost:8000/parse/gdocs/file"
-    yield "   Upload a Google Docs JSON file"
-    yield "\n4. Docx endpoints:"
-    yield "   POST http://localhost:8000/docx/parse  (multipart file upload, .docx -> text)"
-    yield '   POST http://localhost:8000/docx/create (json {"text":"..."} -> returns .docx file)'
-    yield "\nEndpoints are documented at: http://localhost:8000/docs"
+    services = catalog.get("services") if isinstance(catalog, dict) else None
+    if not services:
+        yield "\nNo services defined. Update docs/service_catalog.yaml to document the API surface."
+        yield "=" * 50
+        return
+
+    for index, service in enumerate(services, start=1):
+        yield ""
+        yield from _format_service(service)
+        if index < len(services):
+            yield ""
+
+    yield ""
+    yield "Interactive documentation: http://localhost:8000/docs"
     yield "=" * 50
 
 
 def render_documentation() -> str:
     """Return the documentation banner as a single string."""
+
     return "\n".join(_documentation_lines())
 
 
 def print_documentation() -> None:
     """Print the documentation banner to stdout."""
+
     print(render_documentation())
 
 
 @asynccontextmanager
 async def documentation_lifespan(app: FastAPI) -> AsyncIterator[None]:
     """FastAPI lifespan hook that prints the documentation banner."""
+
     print_documentation()
     yield

--- a/tools-api/code_flow.md
+++ b/tools-api/code_flow.md
@@ -1,57 +1,132 @@
-# Code Flow & Contribution Guide
+# Developer Workflow & Module Playbook
 
-## How the System Works
-- Requests hit FastAPI endpoints (routers/)
-- Routers validate input, call service functions
-- Services do the work (parsing, conversion, etc.)
-- Responses are returned, errors logged centrally
+This guide explains how requests move through Tools API and how to extend the platform with new micro-tools. Use it as the single source of truth when shipping capabilities for n8n, Zapier, or any HTTP-driven orchestration layer.
 
-## Adding a New Module
-1. Create a new router in `app/routers/` (e.g., `convert.py`)
-2. Create a corresponding service in `app/services/` (e.g., `convert_service.py`)
-3. Define Pydantic models for input/output
-4. Register the router in `main.py`
-5. Add tests in `tests/`
-6. Update `requirements.txt` if new dependencies are needed
+---
 
-## Adding an Open Source Tool
-1. Add the tool’s package to `requirements.txt`
-2. Create a service function in `app/services/` that wraps the tool’s API
-3. Expose endpoints via a router in `app/routers/`
-4. Validate input/output with Pydantic models
-5. Add usage examples to `README.md`
+## System Architecture
 
-### Example: Adding `python-docx` support
+1. **Entry point – FastAPI router (`app/routers/`)**
+   - Defines request/response contracts with Pydantic models.
+   - Performs lightweight validation and hands off to services.
+2. **Service layer (`app/services/`)**
+   - Holds pure, testable functions that wrap external libraries or business logic.
+   - Should be free of FastAPI-specific dependencies wherever possible.
+3. **Runtime extensions (`app/runtime/`, `app/extensions/`)**
+   - Background workers, queue adapters, and documentation helpers.
+4. **Delivery surfaces**
+   - REST endpoints exposed through FastAPI (`/docs` for OpenAPI UI).
+   - Queue endpoints that enqueue jobs for RQ/Redis workers.
 
-1. Add `python-docx` to `requirements.txt` (and `python-multipart` for file uploads).
-2. Create `app/services/docx_service.py` with helper functions like `parse_docx_to_text(bytes) -> str` and `create_docx_from_text(str) -> bytes`.
-3. Expose lightweight endpoints in `app/routers/docx.py`:
-	- `POST /docx/parse` (multipart file upload) -> returns JSON {"text": "..."}
-	- `POST /docx/create` (JSON {"text": "..."}) -> returns the .docx file as an attachment
-4. Register the router in `app/main.py` using `app.include_router(docx.router)`.
-5. Add examples to `README.md` showing how n8n HTTP Request nodes can call these endpoints.
+```
+Client → Router → Service → (Queue/Worker)* → Response
+```
+`*` Optional for async workloads.
 
-This repository contains an example implementation following these steps. Use it as a template for adding other file-conversion tools.
+### Directory Map
 
-## Prompt for Contributors
-> To add a new module, follow the steps above. For open source tools, ensure you wrap their API in a service and keep routers thin. Always add tests and update documentation.
+| Path | Purpose |
+| --- | --- |
+| `app/main.py` | FastAPI application setup and router registration. |
+| `app/routers/` | HTTP route definitions and request/response models. |
+| `app/services/` | Core business logic and integrations with third-party libraries. |
+| `app/runtime/` | CLI helpers, background workers, documentation printer. |
+| `docs/service_catalog.yaml` | Source of truth for the human-readable API catalog printed on startup. |
+| `tests/` | Pytest-based coverage for services and routers. |
 
-## Queue & Worker
-- This project supports a Redis + RQ worker model. Add `REDIS_URL` to `.env` or run Redis locally with Docker.
-- Use `python worker.py` to start a worker which will process jobs enqueued by `/parse/queue/*` endpoints.
+---
 
-## Google Docs BatchUpdate Output
-- The parser service outputs Google Docs batchUpdate-style requests with rich text formatting support. Two main functions:
-	- `parse_html_to_docs_sync(html)` - Converts HTML with full style preservation
-	- `parse_markdown_to_docs_sync(md)` - Converts Markdown via HTML with formatting
-- Features include:
-	- Text styling (bold, italic, underline, colors)
-	- Font control (family, size)
-	- Block elements (headings, lists, tables)
-	- Style inheritance and nesting
-- See `rich_text_guide.md` for comprehensive formatting guidelines
-- Typical workflow:
-	1. Create a new empty document via Google Docs API
-	2. Use the returned `documentId` to call `documents.batchUpdate` with the parser's requests
-	3. All formatting and structure will be preserved in the Google Doc
+## Adding a New Tool or Service
+
+Follow these steps to introduce a new capability that feels native to Tools API and remains maintainable long term.
+
+### 1. Scope the capability
+- Document the problem statement, inputs, and expected outputs.
+- Decide if the tool should run synchronously (HTTP request/response) or asynchronously (enqueue + worker).
+- If the integration depends on an external library, note the minimum supported version.
+
+### 2. Model the contract
+- Create request/response models with Pydantic in your router module.
+- Use descriptive field names; align with n8n conventions when possible.
+- Provide default values or enums to make validation errors actionable.
+
+### 3. Implement the service layer
+- Add a new file in `app/services/` (e.g., `my_tool_service.py`).
+- Keep functions stateless and deterministic so they are easy to test.
+- Wrap third-party exceptions and raise meaningful Python exceptions for routers to catch.
+- If the tool can run in the background, expose both async and sync helpers (`async def run_async(...)` and `def run_sync(...)`).
+
+### 4. Wire up the router
+- Create a router module in `app/routers/` (e.g., `my_tool.py`).
+- Define endpoints with clear tags, descriptions, and response models.
+- Import your router in `app/main.py` and register it with `app.include_router(...)`.
+- For queue-backed endpoints, enqueue via `app.services.queue.enqueue` or the appropriate adapter.
+
+### 5. Extend the documentation surfaces
+- **OpenAPI** – Ensure docstrings, `response_model`, and `description` fields are populated so `/docs` renders useful schemas.
+- **Service catalog** – Update `docs/service_catalog.yaml` so operators running the stack locally can see the new API in the startup banner and CLI output.
+  - Use the following skeleton:
+
+    ```yaml
+    - name: "My Tool"
+      summary: "One-line explanation of the capability."
+      docs_url: "http://localhost:8000/docs#/tag-name"
+      endpoints:
+        - method: "POST"
+          path: "/my-tool/run"
+          description: "What the endpoint does."
+          request:
+            content_type: "application/json"
+            model: "MyToolRequest"
+            fields:
+              payload: "string – Required input."
+            example:
+              payload: "example"
+          response:
+            content_type: "application/json"
+            model: "MyToolResponse"
+            fields:
+              result: "string – Summary of the outcome."
+    ```
+- Run `python run_all.py` (or `uvicorn app.main:app --reload`) and confirm the startup banner lists the new endpoints.
+
+### 6. Update dependencies & configuration
+- Add new libraries to `requirements.txt` and pin versions if the upstream API changes often.
+- Surface new environment variables in `app/config.py` with sensible defaults.
+- Document setup steps in the project `README.md` if users must configure credentials.
+
+### 7. Test thoroughly
+- Add unit tests in `tests/` to cover the service and router behaviours.
+- For async queues, add integration-style tests that assert enqueued jobs resolve correctly (see `tests/test_local_queue.py`).
+- Run `pytest` locally and ensure the suite passes before opening a PR.
+
+### 8. Operational readiness checklist
+- Confirm logging uses `app.utils.logger` for consistent formatting.
+- Provide retries or graceful error messaging for network-dependent code.
+- If the tool produces files, document storage expectations (local disk vs. object store) in the README or service catalog notes.
+- Ensure the API contract is backward compatible when modifying existing endpoints.
+
+---
+
+## Queue & Worker Guidance
+
+- Local development uses the in-process queue provided by `app.extensions.local_queue_extension`.
+- Production deployments should wire in Redis + RQ (`redis://` URLs). Update environment variables accordingly.
+- Background workers live in `app/runtime/worker.py`; add handlers there if your tool produces jobs consumed outside FastAPI.
+
+---
+
+## Google Docs Rich Text Reference
+
+- HTML and Markdown conversion helpers live in `app/services/parser_service.py`.
+- The output format is a list of Google Docs `batchUpdate` requests. See `rich_text_guide.md` for styling capabilities.
+- When extending formatting support, update both the service tests and the documentation catalog examples so downstream users know what to expect.
+
+---
+
+## Contributor Tips
+
+- Keep pull requests focused—new tool + documentation + tests.
+- Mention any follow-up tasks or limitations in the PR description so future maintainers can triage improvements quickly.
+- If you touch shared infrastructure (queues, runtime, documentation printer), add regression tests to prevent accidental breakage.
 

--- a/tools-api/docs/service_catalog.yaml
+++ b/tools-api/docs/service_catalog.yaml
@@ -1,0 +1,152 @@
+services:
+  - name: "Rich Text Parser"
+    summary: "Convert HTML or Markdown into Google Docs batchUpdate operations for automated document assembly."
+    docs_url: "http://localhost:8000/docs#/parser"
+    endpoints:
+      - method: "POST"
+        path: "/parse/html"
+        description: "Convert HTML markup into Google Docs batchUpdate requests."
+        request:
+          content_type: "application/json"
+          model: "HTMLParseRequest"
+          fields:
+            html: "string – HTML markup to convert."
+          example:
+            html: "<h1>Hello World</h1><p>This becomes a Google Doc.</p>"
+        response:
+          content_type: "application/json"
+          model: "GoogleDocsBatchUpdate"
+          fields:
+            requests: "list – Google Docs API batchUpdate operations."
+          example:
+            requests:
+              - insertText:
+                  location:
+                    index: 1
+                  text: "Hello World\n"
+      - method: "POST"
+        path: "/parse/markdown"
+        description: "Convert Markdown into Google Docs batchUpdate requests via the HTML pipeline."
+        request:
+          content_type: "application/json"
+          model: "MarkdownParseRequest"
+          fields:
+            markdown: "string – Markdown content to convert."
+          example:
+            markdown: "# Release Notes\n- Item one\n- Item two"
+        response:
+          content_type: "application/json"
+          model: "GoogleDocsBatchUpdate"
+          fields:
+            requests: "list – Google Docs API batchUpdate operations."
+      - method: "POST"
+        path: "/parse/docs/html"
+        description: "Synchronous HTML conversion helper for Google Docs batchUpdate payloads."
+        request:
+          content_type: "application/json"
+          model: "HTMLParseRequest"
+          fields:
+            html: "string – HTML markup to convert."
+        response:
+          content_type: "application/json"
+          fields:
+            requests: "list – Google Docs API batchUpdate operations."
+        notes:
+          - "Optimized for n8n HTTP Request nodes where async queues are unnecessary."
+      - method: "POST"
+        path: "/parse/docs/markdown"
+        description: "Synchronous Markdown conversion helper for Google Docs batchUpdate payloads."
+        request:
+          content_type: "application/json"
+          model: "MarkdownParseRequest"
+          fields:
+            markdown: "string – Markdown content to convert."
+        response:
+          content_type: "application/json"
+          fields:
+            requests: "list – Google Docs API batchUpdate operations."
+      - method: "POST"
+        path: "/parse/queue/html"
+        description: "Enqueue HTML conversion work to Redis/RQ for long-running jobs."
+        request:
+          content_type: "application/json"
+          model: "HTMLParseRequest"
+          fields:
+            html: "string – HTML markup to convert."
+        response:
+          content_type: "application/json"
+          model: "EnqueueResponse"
+          fields:
+            job_id: "string – Identifier that can be polled via /parse/job/{id}."
+      - method: "POST"
+        path: "/parse/queue/markdown"
+        description: "Enqueue Markdown conversion work to Redis/RQ for long-running jobs."
+        request:
+          content_type: "application/json"
+          model: "MarkdownParseRequest"
+          fields:
+            markdown: "string – Markdown content to convert."
+        response:
+          content_type: "application/json"
+          model: "EnqueueResponse"
+          fields:
+            job_id: "string – Identifier that can be polled via /parse/job/{id}."
+      - method: "GET"
+        path: "/parse/job/{job_id}"
+        description: "Check the status of a queued conversion job."
+        response:
+          content_type: "application/json"
+          fields:
+            status: "string – queued|started|finished|failed|unknown."
+            result: "object – Present when status=finished."
+            error: "string – Present when status=failed."
+  - name: "Google Docs JSON Parser"
+    summary: "Extract text, links, and image references from Google Docs JSON exports."
+    docs_url: "http://localhost:8000/docs#/Google_Docs_Parser"
+    endpoints:
+      - method: "POST"
+        path: "/parse/gdocs/json"
+        description: "Parse a Google Docs JSON payload produced by the Google Docs API."
+        request:
+          content_type: "application/json"
+          model: "GoogleDocs JSON"
+          fields:
+            Content: "object – Raw Google Docs document JSON."
+        response:
+          content_type: "application/json"
+          model: "GoogleDocsParseResponse"
+          fields:
+            text: "string – Plain text extracted from the document."
+            urls: "list – Hyperlinks that were present in the document."
+            images: "list – Image URLs present in the document."
+      - method: "POST"
+        path: "/parse/gdocs/file"
+        description: "Upload a Google Docs JSON export file and receive structured output."
+        request:
+          content_type: "multipart/form-data"
+          fields:
+            file: "file – Google Docs JSON export."
+        response:
+          content_type: "application/json"
+          model: "GoogleDocsParseResponse"
+          fields:
+            text: "string"
+            urls: "list"
+            images: "list"
+  - name: "Docx Toolkit"
+    summary: "Parse binary .docx uploads into structured responses and generate documents."
+    docs_url: "http://localhost:8000/docs#/docx"
+    endpoints:
+      - method: "POST"
+        path: "/docx/parse"
+        description: "Upload a binary .docx file and extract plain text."
+        request:
+          content_type: "application/octet-stream"
+          fields:
+            body: "bytes – Raw .docx binary data sent as the HTTP body."
+        response:
+          content_type: "application/json"
+          fields:
+            text: "string – Extracted plain text."
+            size_bytes: "integer – Size of the uploaded file in bytes."
+            content_type: "string – Content-Type header received from the client."

--- a/tools-api/requirements.txt
+++ b/tools-api/requirements.txt
@@ -3,6 +3,7 @@ fastapi
 httpx
 markdown
 pydantic
+pyyaml
 python-docx
 python-dotenv
 python-multipart

--- a/tools-api/tests/test_documentation.py
+++ b/tools-api/tests/test_documentation.py
@@ -1,0 +1,15 @@
+import textwrap
+
+from app.runtime.documentation import render_documentation
+
+
+def test_render_documentation_includes_service_catalog():
+    output = render_documentation()
+
+    normalized = textwrap.dedent(output)
+
+    assert "Rich Text Parser" in normalized
+    assert "POST /parse/html" in normalized
+    assert "Google Docs JSON Parser" in normalized
+    assert "Docx Toolkit" in normalized
+    assert "Interactive documentation: http://localhost:8000/docs" in normalized


### PR DESCRIPTION
## Summary
- replace the terse code_flow guide with an end-to-end playbook for building and documenting new services
- add a YAML-backed service catalog and load it at runtime so the startup banner reflects every tool and its contract
- register the Google Docs parser router and add a regression test that verifies the catalog output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfe84e898c8328b99ba6cd6124032b