### PR TITLE
Add JavaScript panorama splitter endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ nosetests.xml
 .DS_Store
 Thumbs.db
 data/
+
+# JavaScript build artifacts
+tools-api/js_tools/**/node_modules/

--- a/tools-api/README.md
+++ b/tools-api/README.md
@@ -27,6 +27,7 @@
 - **Docx Toolkit** – Parse uploaded `.docx` files into plain text or generate `.docx` documents from JSON payloads.
 - **Queue-Ready Workflows** – Built-in Redis + RQ worker enables durable background processing for large document jobs.
 - **Modular Architecture** – Add new tool routers quickly; see [code_flow.md](./code_flow.md) for an overview.
+- **JavaScript Tool Bridge** – Wrap Node.js utilities (like the panorama splitter) in Python-friendly REST endpoints.
 - **Observability Hooks** – Centralized logging and error handling give SRE and platform teams the visibility they expect.
 
 ```mermaid
@@ -75,6 +76,17 @@ pip install -r requirements.txt
 ```bash
 uvicorn app.main:app --reload
 ```
+
+### JavaScript-powered tools
+Some endpoints rely on Node.js tooling. Install Node 18+ and npm so the API can install dependencies on first run:
+
+```bash
+# Example: ensure dependencies for the bundled panorama splitter are installed
+cd tools-api/js_tools/panosplitter
+npm install
+```
+
+When the API boots it will run `npm install` for you if `node_modules/` is missing.
 
 ### Docker
 ```bash

--- a/tools-api/app/main.py
+++ b/tools-api/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
-from app.routers import parser, docx, gdocs_parser
+from app.routers import docx, gdocs_parser, js_tools, parser
 from app.extensions import local_queue_extension
 from app.utils.logger import logger
 from app.config import settings
@@ -48,6 +48,7 @@ async def log_requests(request: Request, call_next):
 app.include_router(parser.router, prefix="/parse", tags=["parser"])
 app.include_router(docx.router)  # Already has /docx prefix
 app.include_router(gdocs_parser.router)
+app.include_router(js_tools.router)
 local_queue_extension.register(app)
 
 

--- a/tools-api/app/routers/__init__.py
+++ b/tools-api/app/routers/__init__.py
@@ -1,0 +1,10 @@
+"""FastAPI router modules exposed by Tools API."""
+
+from . import docx, gdocs_parser, js_tools, parser  # noqa: F401
+
+__all__ = [
+    "docx",
+    "gdocs_parser",
+    "js_tools",
+    "parser",
+]

--- a/tools-api/app/routers/js_tools.py
+++ b/tools-api/app/routers/js_tools.py
@@ -1,0 +1,60 @@
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from pydantic import BaseModel, Field
+
+from app.services.js_tool_service import JavaScriptToolError, run_panosplitter
+from app.utils.logger import logger
+
+router = APIRouter(prefix="/js-tools", tags=["javascript-tools"])
+
+
+class ImagePayload(BaseModel):
+    filename: str
+    content_type: str
+    base64: str = Field(..., description="Base64 encoded image data")
+    width: int | None = None
+    height: int | None = None
+
+
+class ZipPayload(BaseModel):
+    filename: str
+    base64: str = Field(..., description="Base64 encoded zip archive")
+    content_type: str
+
+
+class PanosplitterMetadata(BaseModel):
+    mode: str
+    slice_count: int
+    slice_width: int
+    slice_height: int
+    scaled_width: int
+    scaled_height: int
+    original_filename: str
+
+
+class PanosplitterResponse(BaseModel):
+    metadata: PanosplitterMetadata
+    zip_file: ZipPayload
+    slices: list[ImagePayload]
+    full_view: ImagePayload
+
+
+@router.post("/panosplitter", response_model=PanosplitterResponse)
+async def panosplitter_endpoint(
+    image: UploadFile = File(..., description="Panorama image to split"),
+    high_res: bool = Form(False, description="Use the high resolution splitting mode"),
+):
+    """Split a panorama image into Instagram-friendly slices using the JavaScript toolchain."""
+
+    try:
+        image_bytes = await image.read()
+        if not image_bytes:
+            raise HTTPException(status_code=400, detail="Uploaded file is empty")
+
+        result = run_panosplitter(image_bytes, high_res=high_res, filename=image.filename)
+        return result
+    except JavaScriptToolError as exc:
+        logger.error("JavaScript tool failed: %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - FastAPI will re-raise as HTTP 500
+        logger.exception("Unexpected error running panosplitter")
+        raise HTTPException(status_code=500, detail="Failed to process image") from exc

--- a/tools-api/app/services/js_tool_service.py
+++ b/tools-api/app/services/js_tool_service.py
@@ -1,0 +1,251 @@
+"""Utilities for bridging FastAPI endpoints to JavaScript-powered tools."""
+from __future__ import annotations
+
+import base64
+import json
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+import zipfile
+
+from app.utils.logger import logger
+
+
+class JavaScriptToolError(RuntimeError):
+    """Raised when a JavaScript-backed tool fails to execute."""
+
+
+@dataclass
+class PanosplitterResult:
+    """Structured result returned from the Node.js panosplitter CLI."""
+
+    mode: str
+    slice_count: int
+    slice_width: int
+    slice_height: int
+    scaled_width: int
+    scaled_height: int
+    slices: List[Dict[str, int]]
+    full_view: Dict[str, int]
+
+
+NODE_EXECUTABLE = shutil.which("node")
+NPM_EXECUTABLE = shutil.which("npm")
+
+
+def _ensure_node_available() -> None:
+    """Verify that the runtime has Node.js installed."""
+
+    if NODE_EXECUTABLE is None:
+        raise JavaScriptToolError(
+            "Node.js is required to execute JavaScript tools. Install Node.js and ensure "
+            "the `node` binary is available on PATH."
+        )
+
+    if NPM_EXECUTABLE is None:
+        raise JavaScriptToolError(
+            "npm is required to install JavaScript tool dependencies. Install Node.js/npm and "
+            "ensure the `npm` binary is available on PATH."
+        )
+
+
+def _ensure_dependencies(tool_dir: Path) -> None:
+    """Install npm dependencies for the JavaScript tool if necessary."""
+
+    node_modules = tool_dir / "node_modules"
+    package_json = tool_dir / "package.json"
+
+    if not package_json.exists():
+        raise JavaScriptToolError(f"Missing package.json in {tool_dir}")
+
+    # Install dependencies when node_modules is missing. The call is idempotent because npm skips reinstall
+    # when modules are already present.
+    if not node_modules.exists():
+        logger.info("Installing npm dependencies for %s", tool_dir)
+        result = subprocess.run(
+            [NPM_EXECUTABLE, "install"],
+            cwd=str(tool_dir),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.error("npm install failed: %s", result.stderr)
+            raise JavaScriptToolError("Failed to install JavaScript tool dependencies")
+
+
+def _parse_cli_output(stdout: str) -> PanosplitterResult:
+    """Parse the JSON payload emitted by the Node.js CLI."""
+
+    stdout = stdout.strip()
+    if not stdout:
+        raise JavaScriptToolError("JavaScript tool returned no output")
+
+    # Some CLIs might emit multiple lines. The JSON payload is expected to be on the last line.
+    json_payload = stdout.splitlines()[-1]
+
+    try:
+        payload = json.loads(json_payload)
+    except json.JSONDecodeError as exc:
+        raise JavaScriptToolError("Unable to decode JavaScript tool output as JSON") from exc
+
+    if "error" in payload:
+        raise JavaScriptToolError(payload["error"])
+
+    try:
+        return PanosplitterResult(
+            mode=payload["mode"],
+            slice_count=int(payload["sliceCount"]),
+            slice_width=int(payload["sliceWidth"]),
+            slice_height=int(payload["sliceHeight"]),
+            scaled_width=int(payload["scaledWidth"]),
+            scaled_height=int(payload["scaledHeight"]),
+            slices=list(payload["slices"]),
+            full_view=dict(payload["fullView"]),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise JavaScriptToolError("JavaScript tool response was missing required fields") from exc
+
+
+def _invoke_panosplitter_cli(
+    cli_path: Path,
+    input_path: Path,
+    output_dir: Path,
+    mode: str,
+    timeout: Optional[int] = 120,
+) -> PanosplitterResult:
+    """Run the Node.js CLI and return the parsed response."""
+
+    command = [
+        NODE_EXECUTABLE,
+        str(cli_path),
+        "--input",
+        str(input_path),
+        "--output",
+        str(output_dir),
+        "--mode",
+        mode,
+    ]
+
+    logger.debug("Running panosplitter CLI: %s", " ".join(command))
+    result = subprocess.run(
+        command,
+        cwd=str(cli_path.parent),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+    if result.returncode != 0:
+        logger.error("JavaScript tool failed: %s", result.stderr)
+        raise JavaScriptToolError("Panosplitter CLI execution failed")
+
+    return _parse_cli_output(result.stdout)
+
+
+def _encode_file(path: Path) -> Dict[str, str]:
+    """Base64 encode a file for transport over HTTP."""
+
+    data = base64.b64encode(path.read_bytes()).decode("utf-8")
+    return {
+        "filename": path.name,
+        "content_type": "image/jpeg",
+        "base64": data,
+    }
+
+
+def _create_zip_payload(directory: Path, zip_name: str = "panosplitter_slices.zip") -> Dict[str, str]:
+    """Bundle the generated assets into a base64-encoded zip file."""
+
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp_file:
+        tmp_path = Path(tmp_file.name)
+
+    try:
+        with zipfile.ZipFile(tmp_path, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+            for file_path in sorted(directory.glob("*.jpg")):
+                zip_file.write(file_path, arcname=file_path.name)
+
+        zip_data = base64.b64encode(tmp_path.read_bytes()).decode("utf-8")
+        return {
+            "filename": zip_name,
+            "base64": zip_data,
+            "content_type": "application/zip",
+        }
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def run_panosplitter(
+    image_bytes: bytes,
+    *,
+    high_res: bool = False,
+    filename: Optional[str] = None,
+    timeout: Optional[int] = 120,
+) -> Dict[str, object]:
+    """Execute the JavaScript panorama splitter and return assets + metadata."""
+
+    _ensure_node_available()
+
+    tool_dir = Path(__file__).resolve().parents[2] / "js_tools" / "panosplitter"
+    cli_path = tool_dir / "cli.js"
+    if not cli_path.exists():
+        raise JavaScriptToolError("Panosplitter CLI script not found")
+
+    _ensure_dependencies(tool_dir)
+
+    mode = "highres" if high_res else "standard"
+    filename = filename or "upload.jpg"
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_dir_path = Path(tmp_dir)
+        input_path = tmp_dir_path / filename
+        output_dir = tmp_dir_path / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        input_path.write_bytes(image_bytes)
+
+        result = _invoke_panosplitter_cli(cli_path, input_path, output_dir, mode, timeout=timeout)
+
+        slices_payload = []
+        for slice_info in result.slices:
+            file_path = output_dir / slice_info["filename"]
+            if not file_path.exists():
+                raise JavaScriptToolError(f"Expected slice not found: {file_path.name}")
+            encoded = _encode_file(file_path)
+            encoded.update({
+                "width": slice_info.get("width"),
+                "height": slice_info.get("height"),
+            })
+            slices_payload.append(encoded)
+
+        full_view_path = output_dir / result.full_view["filename"]
+        if not full_view_path.exists():
+            raise JavaScriptToolError("Full view image was not generated by the JavaScript tool")
+
+        full_view_payload = _encode_file(full_view_path)
+        full_view_payload.update({
+            "width": result.full_view.get("width"),
+            "height": result.full_view.get("height"),
+        })
+
+        zip_payload = _create_zip_payload(output_dir)
+
+        return {
+            "metadata": {
+                "mode": result.mode,
+                "slice_count": result.slice_count,
+                "slice_width": result.slice_width,
+                "slice_height": result.slice_height,
+                "scaled_width": result.scaled_width,
+                "scaled_height": result.scaled_height,
+                "original_filename": filename,
+            },
+            "zip_file": zip_payload,
+            "slices": slices_payload,
+            "full_view": full_view_payload,
+        }

--- a/tools-api/docs/service_catalog.yaml
+++ b/tools-api/docs/service_catalog.yaml
@@ -170,3 +170,28 @@ services:
             text: "string – Extracted plain text."
             size_bytes: "integer – Size of the uploaded file in bytes."
             content_type: "string – Content-Type header received from the client."
+  - name: "JavaScript Tool Bridge"
+    summary: "Expose curated Node.js utilities – like the panorama splitter – through Tools API endpoints."
+    docs_url: "http://localhost:8000/docs#/javascript-tools/panosplitter_js_tools_panosplitter_post"
+    endpoints:
+      - method: "POST"
+        path: "/js-tools/panosplitter"
+        headline: "Panorama to Instagram-ready tiles"
+        tagline: "Upload a panoramic image and receive Instagram-ready slices plus a shareable full preview."
+        description: "Runs the bundled JavaScript panosplitter CLI via Node.js to generate slices and a full-view preview."
+        request:
+          content_type: "multipart/form-data"
+          fields:
+            image: "file – Panorama image (JPEG/PNG) to process."
+            high_res: "boolean – Optional. Enable to keep the original height for higher resolution slices."
+        response:
+          content_type: "application/json"
+          model: "PanosplitterResponse"
+          fields:
+            metadata: "object – Slice counts, dimensions, and original filename."
+            zip_file: "object – Base64 zip archive bundling all generated JPEGs."
+            slices: "list – Base64-encoded slices with dimensions."
+            full_view: "object – Base64-encoded hero panel for carousel cover."
+        notes:
+          - "Dependencies install automatically on first run (Node.js + npm required)."
+          - "Returns both individual slices and a convenience .zip for workflows like n8n."

--- a/tools-api/js_tools/panosplitter/cli.js
+++ b/tools-api/js_tools/panosplitter/cli.js
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const sharp = require('sharp');
+const minimist = require('minimist');
+
+function calculateOptimalScaling(originalWidth, originalHeight, highResMode) {
+  const aspectRatio = 4 / 5;
+  const standardWidth = 1080;
+  const standardHeight = Math.round(standardWidth / aspectRatio);
+  const minSlices = 2;
+
+  let sliceWidth = standardWidth;
+  let sliceHeight = standardHeight;
+
+  if (highResMode) {
+    sliceHeight = originalHeight;
+    sliceWidth = Math.round(sliceHeight * aspectRatio);
+  }
+
+  const scaleFactor = sliceHeight / originalHeight;
+  const baseScaledWidth = Math.round(originalWidth * scaleFactor);
+  const fullSlices = Math.floor(baseScaledWidth / sliceWidth);
+  const remainingWidth = baseScaledWidth - (fullSlices * sliceWidth);
+
+  let finalSliceCount;
+  let finalScaledWidth;
+  let finalScaledHeight;
+
+  if (fullSlices < minSlices) {
+    finalSliceCount = minSlices;
+    finalScaledWidth = minSlices * sliceWidth;
+    const adjustedScaleFactor = finalScaledWidth / originalWidth;
+    finalScaledHeight = Math.round(originalHeight * adjustedScaleFactor);
+  } else if (remainingWidth > (sliceWidth / 2)) {
+    finalSliceCount = fullSlices + 1;
+    finalScaledWidth = finalSliceCount * sliceWidth;
+    const adjustedScaleFactor = finalScaledWidth / originalWidth;
+    finalScaledHeight = Math.round(originalHeight * adjustedScaleFactor);
+  } else {
+    finalSliceCount = fullSlices;
+    finalScaledWidth = finalSliceCount * sliceWidth;
+    finalScaledHeight = sliceHeight;
+  }
+
+  return {
+    sliceWidth,
+    sliceHeight,
+    sliceCount: finalSliceCount,
+    scaledWidth: finalScaledWidth,
+    scaledHeight: finalScaledHeight
+  };
+}
+
+async function createFullViewImage({ inputPath, outputPath, originalWidth, originalHeight, sliceWidth, sliceHeight }) {
+  const margin = Math.round(sliceWidth * 0.08);
+  const availableWidth = sliceWidth - margin * 2;
+  const availableHeight = sliceHeight - margin * 2;
+  const originalAspect = originalWidth / originalHeight;
+
+  let panoWidth;
+  let panoHeight;
+
+  if (originalAspect > availableWidth / availableHeight) {
+    panoWidth = availableWidth;
+    panoHeight = panoWidth / originalAspect;
+  } else {
+    panoHeight = availableHeight;
+    panoWidth = panoHeight * originalAspect;
+  }
+
+  panoWidth = Math.max(1, Math.round(panoWidth));
+  panoHeight = Math.max(1, Math.round(panoHeight));
+
+  const x = Math.max(0, Math.round((sliceWidth - panoWidth) / 2));
+  const y = Math.max(0, Math.round((sliceHeight - panoHeight) / 2));
+
+  const panoramaBuffer = await sharp(inputPath)
+    .resize({
+      width: panoWidth,
+      height: panoHeight,
+      fit: 'inside'
+    })
+    .jpeg({ quality: 95 })
+    .toBuffer();
+
+  const background = sharp({
+    create: {
+      width: sliceWidth,
+      height: sliceHeight,
+      channels: 3,
+      background: '#ffffff'
+    }
+  });
+
+  const canvas = background.composite([
+    {
+      input: panoramaBuffer,
+      top: y,
+      left: x
+    }
+  ]);
+
+  // Add subtle border similar to the web app implementation
+  const borderWidth = 1;
+  const borderColor = { r: 238, g: 238, b: 238, alpha: 1 };
+  const borderOverlay = {
+    create: {
+      width: sliceWidth,
+      height: sliceHeight,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 0 }
+    }
+  };
+
+  const overlay = await sharp(borderOverlay)
+    .composite([
+      {
+        input: {
+          create: {
+            width: sliceWidth - borderWidth * 2,
+            height: sliceHeight - borderWidth * 2,
+            channels: 4,
+            background: borderColor
+          }
+        },
+        top: borderWidth,
+        left: borderWidth,
+        blend: 'dest-out'
+      }
+    ])
+    .png()
+    .toBuffer();
+
+  const result = await canvas
+    .composite([
+      {
+        input: overlay,
+        blend: 'over'
+      }
+    ])
+    .jpeg({ quality: 95 })
+    .toBuffer();
+
+  await sharp(result).toFile(outputPath);
+}
+
+async function run() {
+  const args = minimist(process.argv.slice(2), {
+    boolean: ['highRes'],
+    alias: { i: 'input', o: 'output', m: 'mode' },
+    default: { mode: 'standard' }
+  });
+
+  const inputPath = args.input ? path.resolve(args.input) : null;
+  const outputDir = args.output ? path.resolve(args.output) : null;
+  const modeFlag = (args.mode || '').toLowerCase();
+  const mode = args.highRes || modeFlag === 'highres' ? 'highres' : 'standard';
+
+  if (!inputPath || !outputDir) {
+    console.error(JSON.stringify({ error: 'Both --input and --output are required.' }));
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(inputPath)) {
+    console.error(JSON.stringify({ error: `Input file not found: ${inputPath}` }));
+    process.exit(1);
+  }
+
+  await fs.promises.mkdir(outputDir, { recursive: true });
+
+  try {
+    const metadata = await sharp(inputPath).metadata();
+    const { width: originalWidth, height: originalHeight } = metadata;
+
+    if (!originalWidth || !originalHeight) {
+      throw new Error('Unable to determine image dimensions');
+    }
+
+    const scaling = calculateOptimalScaling(originalWidth, originalHeight, mode === 'highres');
+    const resizedBuffer = await sharp(inputPath)
+      .resize({
+        width: scaling.scaledWidth,
+        height: scaling.scaledHeight,
+        fit: 'fill'
+      })
+      .jpeg({ quality: 95 })
+      .toBuffer();
+
+    const slices = [];
+    for (let index = 0; index < scaling.sliceCount; index += 1) {
+      const left = index * scaling.sliceWidth;
+      const width = Math.min(scaling.sliceWidth, scaling.scaledWidth - left);
+
+      const slicePath = path.join(outputDir, `slice-${String(index + 1).padStart(2, '0')}.jpg`);
+
+      await sharp(resizedBuffer)
+        .extract({
+          left,
+          top: 0,
+          width,
+          height: scaling.scaledHeight
+        })
+        .resize({
+          width: scaling.sliceWidth,
+          height: scaling.sliceHeight,
+          fit: 'fill'
+        })
+        .jpeg({ quality: 95 })
+        .toFile(slicePath);
+
+      slices.push({
+        filename: path.basename(slicePath),
+        width: scaling.sliceWidth,
+        height: scaling.sliceHeight
+      });
+    }
+
+    const fullViewName = 'full-view.jpg';
+    const fullViewPath = path.join(outputDir, fullViewName);
+    await createFullViewImage({
+      inputPath,
+      outputPath: fullViewPath,
+      originalWidth,
+      originalHeight,
+      sliceWidth: scaling.sliceWidth,
+      sliceHeight: scaling.sliceHeight
+    });
+
+    const response = {
+      mode,
+      sliceCount: scaling.sliceCount,
+      sliceWidth: scaling.sliceWidth,
+      sliceHeight: scaling.sliceHeight,
+      scaledWidth: scaling.scaledWidth,
+      scaledHeight: scaling.scaledHeight,
+      slices,
+      fullView: {
+        filename: fullViewName,
+        width: scaling.sliceWidth,
+        height: scaling.sliceHeight
+      }
+    };
+
+    console.log(JSON.stringify(response));
+  } catch (error) {
+    console.error(JSON.stringify({ error: error.message }));
+    process.exit(1);
+  }
+}
+
+run();

--- a/tools-api/js_tools/panosplitter/package-lock.json
+++ b/tools-api/js_tools/panosplitter/package-lock.json
@@ -1,0 +1,533 @@
+{
+  "name": "panosplitter",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "panosplitter",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "minimist": "^1.2.8",
+        "sharp": "^0.34.4"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
+      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.4.tgz",
+      "integrity": "sha512-sitdlPzDVyvmINUdJle3TNHl+AG9QcwiAMsXmccqsCOMZNIdW2/7S26w0LyU8euiLVzFBL3dXPwVCq/ODnf2vA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.4.tgz",
+      "integrity": "sha512-rZheupWIoa3+SOdF/IcUe1ah4ZDpKBGWcsPX6MT0lYniH9micvIU7HQkYTfrx5Xi8u+YqwLtxC/3vl8TQN6rMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-QzWAKo7kpHxbuHqUC28DZ9pIKpSi2ts2OJnoIGI26+HMgq92ZZ4vk8iJd4XsxN+tYfNJxzH6W62X5eTcsBymHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Ju+g2xn1E2AKO6YBhxjj+ACcsPQRHT0bhpglxcEf+3uyPY+/gL8veniKoo96335ZaPo03bdDXMv0t+BBFAbmRA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.3.tgz",
+      "integrity": "sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.3.tgz",
+      "integrity": "sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.3.tgz",
+      "integrity": "sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.3.tgz",
+      "integrity": "sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.3.tgz",
+      "integrity": "sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.3.tgz",
+      "integrity": "sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.3.tgz",
+      "integrity": "sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.4.tgz",
+      "integrity": "sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.4.tgz",
+      "integrity": "sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.4.tgz",
+      "integrity": "sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.4.tgz",
+      "integrity": "sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.4.tgz",
+      "integrity": "sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.4.tgz",
+      "integrity": "sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.4.tgz",
+      "integrity": "sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.4.tgz",
+      "integrity": "sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.5.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.4.tgz",
+      "integrity": "sha512-2Q250do/5WXTwxW3zjsEuMSv5sUU4Tq9VThWKlU2EYLm4MB7ZeMwF+SFJutldYODXF6jzc6YEOC+VfX0SZQPqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.4.tgz",
+      "integrity": "sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.4.tgz",
+      "integrity": "sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+      "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.4.tgz",
+      "integrity": "sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.0",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.4",
+        "@img/sharp-darwin-x64": "0.34.4",
+        "@img/sharp-libvips-darwin-arm64": "1.2.3",
+        "@img/sharp-libvips-darwin-x64": "1.2.3",
+        "@img/sharp-libvips-linux-arm": "1.2.3",
+        "@img/sharp-libvips-linux-arm64": "1.2.3",
+        "@img/sharp-libvips-linux-ppc64": "1.2.3",
+        "@img/sharp-libvips-linux-s390x": "1.2.3",
+        "@img/sharp-libvips-linux-x64": "1.2.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.3",
+        "@img/sharp-linux-arm": "0.34.4",
+        "@img/sharp-linux-arm64": "0.34.4",
+        "@img/sharp-linux-ppc64": "0.34.4",
+        "@img/sharp-linux-s390x": "0.34.4",
+        "@img/sharp-linux-x64": "0.34.4",
+        "@img/sharp-linuxmusl-arm64": "0.34.4",
+        "@img/sharp-linuxmusl-x64": "0.34.4",
+        "@img/sharp-wasm32": "0.34.4",
+        "@img/sharp-win32-arm64": "0.34.4",
+        "@img/sharp-win32-ia32": "0.34.4",
+        "@img/sharp-win32-x64": "0.34.4"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    }
+  }
+}

--- a/tools-api/js_tools/panosplitter/package.json
+++ b/tools-api/js_tools/panosplitter/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "tools-api-panosplitter",
+  "version": "1.0.0",
+  "description": "CLI wrapper that slices panorama images into Instagram-ready panels for Tools API.",
+  "bin": {
+    "panosplitter-cli": "cli.js"
+  },
+  "scripts": {
+    "install": "node -e 'process.exit(0)'"
+  },
+  "keywords": [
+    "panorama",
+    "instagram",
+    "sharp",
+    "tools-api"
+  ],
+  "author": "Tools API",
+  "license": "MIT",
+  "type": "commonjs",
+  "dependencies": {
+    "minimist": "^1.2.8",
+    "sharp": "^0.33.2"
+  }
+}

--- a/tools-api/tests/test_js_tools.py
+++ b/tools-api/tests/test_js_tools.py
@@ -1,0 +1,104 @@
+import base64
+import io
+import zipfile
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.routers.js_tools as js_tools_router
+from app.main import app
+from app.services import js_tool_service
+from app.services.js_tool_service import PanosplitterResult
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_run_panosplitter_service(monkeypatch):
+    monkeypatch.setattr(js_tool_service, "_ensure_node_available", lambda: None)
+    monkeypatch.setattr(js_tool_service, "_ensure_dependencies", lambda _tool_dir: None)
+
+    def fake_invoke(cli_path, input_path, output_dir, mode, timeout=None):
+        # Create fake output assets
+        (output_dir / "slice-01.jpg").write_bytes(b"slice-one")
+        (output_dir / "slice-02.jpg").write_bytes(b"slice-two")
+        (output_dir / "full-view.jpg").write_bytes(b"full-view")
+        return PanosplitterResult(
+            mode=mode,
+            slice_count=2,
+            slice_width=1080,
+            slice_height=1350,
+            scaled_width=2160,
+            scaled_height=1350,
+            slices=[
+                {"filename": "slice-01.jpg", "width": 1080, "height": 1350},
+                {"filename": "slice-02.jpg", "width": 1080, "height": 1350},
+            ],
+            full_view={"filename": "full-view.jpg", "width": 1080, "height": 1350},
+        )
+
+    monkeypatch.setattr(js_tool_service, "_invoke_panosplitter_cli", fake_invoke)
+
+    result = js_tool_service.run_panosplitter(b"image-bytes", filename="panorama.jpg")
+
+    assert result["metadata"]["slice_count"] == 2
+    assert len(result["slices"]) == 2
+    assert base64.b64decode(result["slices"][0]["base64"]) == b"slice-one"
+    assert result["full_view"]["width"] == 1080
+
+    zip_payload = base64.b64decode(result["zip_file"]["base64"])
+    with zipfile.ZipFile(io.BytesIO(zip_payload)) as archive:
+        assert set(archive.namelist()) == {"full-view.jpg", "slice-01.jpg", "slice-02.jpg"}
+
+
+def test_panosplitter_endpoint(client, monkeypatch):
+    sample_result = {
+        "metadata": {
+            "mode": "standard",
+            "slice_count": 2,
+            "slice_width": 1080,
+            "slice_height": 1350,
+            "scaled_width": 2160,
+            "scaled_height": 1350,
+            "original_filename": "demo.jpg",
+        },
+        "zip_file": {
+            "filename": "panosplitter_slices.zip",
+            "base64": base64.b64encode(b"zip-bytes").decode("utf-8"),
+            "content_type": "application/zip",
+        },
+        "slices": [
+            {
+                "filename": "slice-01.jpg",
+                "content_type": "image/jpeg",
+                "base64": base64.b64encode(b"slice-one").decode("utf-8"),
+                "width": 1080,
+                "height": 1350,
+            }
+        ],
+        "full_view": {
+            "filename": "full-view.jpg",
+            "content_type": "image/jpeg",
+            "base64": base64.b64encode(b"full-view").decode("utf-8"),
+            "width": 1080,
+            "height": 1350,
+        },
+    }
+
+    fake_runner = lambda *args, **kwargs: sample_result
+
+    monkeypatch.setattr(js_tool_service, "run_panosplitter", fake_runner)
+    monkeypatch.setattr(js_tools_router, "run_panosplitter", fake_runner)
+
+    response = client.post(
+        "/js-tools/panosplitter",
+        files={"image": ("demo.jpg", b"image-bytes", "image/jpeg")},
+        data={"high_res": "false"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["metadata"]["slice_count"] == 2
+    assert payload["slices"][0]["filename"] == "slice-01.jpg"


### PR DESCRIPTION
## Summary
- add a Node.js panorama splitter CLI and wire it into a new `/js-tools/panosplitter` FastAPI router
- introduce a Python service layer that manages Node/npm dependencies and wraps CLI results for HTTP responses
- update documentation, service catalog, and tests to cover the JavaScript tool bridge

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e047aae838832890f614ef2dbc0fd4