### PR TITLE
Add yt-dlp media toolkit endpoint

### DIFF
--- a/tools-api/README.md
+++ b/tools-api/README.md
@@ -28,6 +28,7 @@
 - **Queue-Ready Workflows** – Built-in Redis + RQ worker enables durable background processing for large document jobs.
 - **Modular Architecture** – Add new tool routers quickly; see [code_flow.md](./code_flow.md) for an overview.
 - **JavaScript Tool Bridge** – Wrap Node.js utilities (like the panorama splitter and Cobalt media downloader) in Python-friendly REST endpoints with binary-friendly delivery for n8n.
+- **Media Toolkit** – Use the bundled yt-dlp endpoint to inspect streams or fetch downloadable media with automation-ready headers.
 - **Observability Hooks** – Centralized logging and error handling give SRE and platform teams the visibility they expect.
 
 ```mermaid
@@ -106,6 +107,22 @@ export COBALT_API_TIMEOUT="90"
 ```
 
 Once configured you can `POST /js-tools/cobalt` with any options supported by Cobalt's schema (for example `audioFormat`, `videoQuality`, or service-specific flags). Default responses return the raw JSON from Cobalt. Include `{"response_format": "binary"}` to download the media bytes directly via Tools API.
+
+#### yt-dlp media helper
+Tools API now ships with a thin wrapper around [yt-dlp](https://github.com/yt-dlp/yt-dlp) for quick metadata lookups or direct downloads:
+
+```bash
+curl -X POST http://localhost:8000/media/yt-dlp \
+  -H "Content-Type: application/json" \
+  -d '{
+        "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        "options": {"format": "bestvideo+bestaudio/best"}
+      }'
+```
+
+- Default responses return the full yt-dlp metadata, perfect for agent reasoning or UI previews.
+- Set `"response_format": "binary"` to receive the media stream directly. The response includes `Content-Disposition` and `X-YtDlp-Metadata` headers to keep n8n or Zapier automations informed about the download.
+- Pass optional headers (cookies, auth) or proxy settings via the `options` object to handle restricted content.
 
 ### Docker
 ```bash

--- a/tools-api/app/main.py
+++ b/tools-api/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
-from app.routers import docx, gdocs_parser, js_tools, parser
+from app.routers import docx, gdocs_parser, js_tools, media, parser
 from app.extensions import local_queue_extension
 from app.utils.logger import logger
 from app.config import settings
@@ -49,6 +49,7 @@ app.include_router(parser.router, prefix="/parse", tags=["parser"])
 app.include_router(docx.router)  # Already has /docx prefix
 app.include_router(gdocs_parser.router)
 app.include_router(js_tools.router)
+app.include_router(media.router)
 local_queue_extension.register(app)
 
 

--- a/tools-api/app/routers/__init__.py
+++ b/tools-api/app/routers/__init__.py
@@ -1,10 +1,11 @@
 """FastAPI router modules exposed by Tools API."""
 
-from . import docx, gdocs_parser, js_tools, parser  # noqa: F401
+from . import docx, gdocs_parser, js_tools, media, parser  # noqa: F401
 
 __all__ = [
     "docx",
     "gdocs_parser",
     "js_tools",
+    "media",
     "parser",
 ]

--- a/tools-api/app/routers/media.py
+++ b/tools-api/app/routers/media.py
@@ -1,0 +1,108 @@
+"""Endpoints for media tooling such as yt-dlp."""
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, Dict, Literal
+from urllib.parse import quote
+
+from fastapi import APIRouter, HTTPException
+from fastapi.encoders import jsonable_encoder
+from pydantic import AnyHttpUrl, BaseModel, Field
+
+from app.services.yt_dlp_service import DownloadResult, YtDlpServiceError, yt_dlp_service
+from app.utils.logger import logger
+
+router = APIRouter(prefix="/media", tags=["media-tools"])
+
+
+class YtDlpOptions(BaseModel):
+    """Subset of yt-dlp options exposed through the API."""
+
+    format: str | None = Field(
+        default=None, description="yt-dlp format selector, for example 'bestvideo+bestaudio/best'."
+    )
+    noplaylist: bool = Field(default=True, description="Download a single video even if the URL is a playlist.")
+    playlist_items: str | None = Field(
+        default=None,
+        description="Select specific playlist items (yt-dlp playlist_items syntax).",
+    )
+    http_headers: Dict[str, str] | None = Field(
+        default=None,
+        description="Optional HTTP headers to send with the request (e.g. cookies or authorization).",
+    )
+    proxy: str | None = Field(default=None, description="Optional proxy URL passed directly to yt-dlp.")
+
+    def to_yt_dlp_kwargs(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {}
+        if self.format:
+            payload["format"] = self.format
+        payload["noplaylist"] = self.noplaylist
+        if self.playlist_items:
+            payload["playlist_items"] = self.playlist_items
+        if self.http_headers:
+            payload["http_headers"] = self.http_headers
+        if self.proxy:
+            payload["proxy"] = self.proxy
+        return payload
+
+
+class YtDlpRequest(BaseModel):
+    url: AnyHttpUrl = Field(..., description="URL understood by yt-dlp.")
+    response_format: Literal["json", "binary"] = Field(
+        default="json",
+        description="Return metadata as JSON (default) or stream the downloaded media as binary.",
+    )
+    filename: str | None = Field(
+        default=None,
+        description="Optional filename to use when returning binary content. Defaults to yt-dlp's detected name.",
+    )
+    options: YtDlpOptions = Field(default_factory=YtDlpOptions, description="Advanced yt-dlp options.")
+
+
+class YtDlpMetadataResponse(BaseModel):
+    metadata: Dict[str, Any]
+
+
+def _content_disposition(filename: str) -> str:
+    encoded = quote(filename)
+    return f"attachment; filename*=UTF-8''{encoded}"
+
+
+def _metadata_header(metadata: Dict[str, Any]) -> str:
+    json_payload = json.dumps(jsonable_encoder(metadata), ensure_ascii=False)
+    return base64.b64encode(json_payload.encode("utf-8")).decode("utf-8")
+
+
+@router.post("/yt-dlp", response_model=YtDlpMetadataResponse)
+async def yt_dlp_endpoint(request: YtDlpRequest):
+    """Fetch metadata or download media using yt-dlp with safe defaults."""
+
+    url = str(request.url)
+    options = request.options.to_yt_dlp_kwargs()
+
+    try:
+        if request.response_format == "binary":
+            download: DownloadResult = yt_dlp_service.download(
+                url,
+                options=options,
+                filename_override=request.filename,
+            )
+            headers = {
+                "Content-Disposition": _content_disposition(download.filename),
+                "X-YtDlp-Metadata": _metadata_header(download.metadata),
+            }
+            return _BinaryResponse(download, headers)
+
+        metadata = yt_dlp_service.extract_info(url, options=options)
+        return YtDlpMetadataResponse(metadata=jsonable_encoder(metadata))
+    except YtDlpServiceError as exc:
+        logger.error("yt-dlp request failed: %s", exc)
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+def _BinaryResponse(result: DownloadResult, headers: Dict[str, str]):
+    from fastapi import Response
+
+    return Response(content=result.content, media_type=result.content_type, headers=headers)
+

--- a/tools-api/app/services/yt_dlp_service.py
+++ b/tools-api/app/services/yt_dlp_service.py
@@ -1,0 +1,155 @@
+"""Service wrapper around yt-dlp to expose downloads via FastAPI."""
+from __future__ import annotations
+
+import base64
+import json
+import mimetypes
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+from app.utils.logger import logger
+
+
+class YtDlpServiceError(RuntimeError):
+    """Raised when yt-dlp fails to process a request."""
+
+
+@dataclass
+class DownloadResult:
+    """Container for downloaded binary payloads."""
+
+    content: bytes
+    filename: str
+    content_type: str
+    metadata: Dict[str, Any]
+
+
+def _ensure_yt_dlp() -> Any:
+    """Import yt_dlp lazily so requirements remain optional for some commands."""
+
+    try:
+        import yt_dlp  # type: ignore
+    except ImportError as exc:  # pragma: no cover - fast failure when dependency missing
+        raise YtDlpServiceError(
+            "yt-dlp is not installed. Install it via 'pip install yt-dlp' to enable the media tools."
+        ) from exc
+
+    return yt_dlp
+
+
+class YtDlpService:
+    """Thin wrapper around yt-dlp with opinionated defaults."""
+
+    def __init__(self, *, base_options: Dict[str, Any] | None = None) -> None:
+        self.base_options = base_options or {}
+
+    def _build_options(self, overrides: Dict[str, Any]) -> Dict[str, Any]:
+        options: Dict[str, Any] = {
+            "quiet": True,
+            "no_warnings": True,
+            "ignoreerrors": False,
+            "concurrent_fragment_downloads": 3,
+        }
+        options.update(self.base_options)
+        options.update({k: v for k, v in overrides.items() if v is not None})
+        return options
+
+    def extract_info(self, url: str, *, options: Dict[str, Any]) -> Dict[str, Any]:
+        """Return metadata about the supplied URL without downloading content."""
+
+        yt_dlp = _ensure_yt_dlp()
+        merged_options = self._build_options({"skip_download": True, **options})
+
+        logger.debug("Fetching yt-dlp metadata for %s with options %s", url, merged_options)
+        try:
+            with yt_dlp.YoutubeDL(merged_options) as ydl:
+                info = ydl.extract_info(url, download=False)
+        except Exception as exc:  # pragma: no cover - yt-dlp raises many custom errors
+            logger.error("yt-dlp metadata extraction failed: %s", exc)
+            raise YtDlpServiceError(str(exc)) from exc
+
+        return info
+
+    def download(self, url: str, *, options: Dict[str, Any], filename_override: str | None = None) -> DownloadResult:
+        """Download the media payload and return the bytes plus metadata."""
+
+        yt_dlp = _ensure_yt_dlp()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            merged_options = self._build_options({
+                "skip_download": False,
+                "outtmpl": str(tmp_path / "%(title)s.%(ext)s"),
+                **options,
+            })
+
+            logger.debug("Downloading media via yt-dlp for %s with options %s", url, merged_options)
+            try:
+                with yt_dlp.YoutubeDL(merged_options) as ydl:
+                    info = ydl.extract_info(url, download=True)
+            except Exception as exc:  # pragma: no cover - yt-dlp raises many custom errors
+                logger.error("yt-dlp download failed: %s", exc)
+                raise YtDlpServiceError(str(exc)) from exc
+
+            download_path = self._resolve_download_path(info)
+            if download_path is None:
+                logger.error("yt-dlp did not report a downloaded file path")
+                raise YtDlpServiceError("Download completed but no file path was reported by yt-dlp")
+
+            path = Path(download_path)
+            if not path.exists():
+                logger.error("yt-dlp reported file %s but it does not exist", path)
+                raise YtDlpServiceError("yt-dlp reported a downloaded file that could not be found")
+
+            filename = filename_override or path.name
+            content = path.read_bytes()
+            content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+
+            metadata = self._serializable_metadata(info)
+
+            return DownloadResult(content=content, filename=filename, content_type=content_type, metadata=metadata)
+
+    def _resolve_download_path(self, info: Dict[str, Any]) -> str | None:
+        """Find the best guess at the downloaded file path from a yt-dlp info dict."""
+
+        if "_filename" in info and info["_filename"]:
+            return str(info["_filename"])
+
+        requested_downloads = info.get("requested_downloads")
+        if isinstance(requested_downloads, list) and requested_downloads:
+            filepath = requested_downloads[0].get("filepath")
+            if filepath:
+                return str(filepath)
+
+        # Some playlist requests include entries under "entries".
+        entries = info.get("entries")
+        if isinstance(entries, list) and entries:
+            first_entry = entries[0]
+            if isinstance(first_entry, dict):
+                return self._resolve_download_path(first_entry)
+
+        return None
+
+    def _serializable_metadata(self, info: Dict[str, Any]) -> Dict[str, Any]:
+        """Ensure the metadata can be encoded as JSON for headers/response bodies."""
+
+        try:
+            json.dumps(info)
+            return info
+        except TypeError:
+            safe_payload = json.loads(json.dumps(info, default=self._encode_binary_fields))
+            return safe_payload
+
+    def _encode_binary_fields(self, value: Any) -> str:
+        """Convert non-serializable values into JSON friendly representations."""
+
+        if isinstance(value, (bytes, bytearray)):
+            return base64.b64encode(value).decode("utf-8")
+        return str(value)
+
+
+# Shared singleton so FastAPI routes can import and reuse it.
+yt_dlp_service = YtDlpService()
+

--- a/tools-api/docs/service_catalog.yaml
+++ b/tools-api/docs/service_catalog.yaml
@@ -309,6 +309,38 @@
           }
         }
       ]
+    },
+    {
+      "name": "Media Toolkit",
+      "summary": "Download or inspect online media using the bundled yt-dlp integration.",
+      "docs_url": "http://localhost:8000/docs#/media-tools/yt_dlp_media_yt_dlp_post",
+      "endpoints": [
+        {
+          "method": "POST",
+          "path": "/media/yt-dlp",
+          "headline": "One-call yt-dlp",
+          "tagline": "Request metadata or stream downloads from any URL yt-dlp supports.",
+          "description": "Wraps yt-dlp with safe defaults for agent and automation workflows.",
+          "request": {
+            "content_type": "application/json",
+            "fields": {
+              "url": "string – URL to inspect or download.",
+              "response_format": "string – 'json' (default metadata) or 'binary' to stream the file.",
+              "filename": "string – Optional filename override when streaming the binary response.",
+              "options": "object – Optional yt-dlp options such as format, playlist_items, proxy, or custom headers."
+            }
+          },
+          "response": {
+            "content_type": "application/json | video/* | audio/*",
+            "fields": {
+              "metadata": "object – yt-dlp info dictionary mirroring the CLI output when response_format=json."
+            },
+            "notes": [
+              "Binary responses include automation-friendly headers: Content-Disposition and X-YtDlp-Metadata (base64 JSON)."
+            ]
+          }
+        }
+      ]
     }
   ]
 }

--- a/tools-api/requirements.txt
+++ b/tools-api/requirements.txt
@@ -15,3 +15,4 @@ redis
 rq
 uvicorn
 ttkbootstrap
+yt-dlp

--- a/tools-api/tests/test_media.py
+++ b/tools-api/tests/test_media.py
@@ -1,0 +1,84 @@
+import base64
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.routers.media as media_router
+from app.main import app
+from app.services.yt_dlp_service import DownloadResult
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_yt_dlp_metadata_endpoint(client, monkeypatch):
+    sample_metadata = {"id": "demo", "title": "Sample", "duration": 10}
+
+    def fake_extract(url: str, *, options):
+        assert url == "https://example.com/video"
+        assert options["noplaylist"] is True
+        return sample_metadata
+
+    monkeypatch.setattr(media_router.yt_dlp_service, "extract_info", fake_extract)
+
+    response = client.post(
+        "/media/yt-dlp",
+        json={"url": "https://example.com/video"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["metadata"] == sample_metadata
+
+
+def test_yt_dlp_binary_endpoint(client, monkeypatch):
+    metadata = {"id": "demo", "title": "Sample", "ext": "mp4"}
+
+    def fake_download(url: str, *, options, filename_override=None):
+        assert filename_override == "custom.mp4"
+        return DownloadResult(
+            content=b"video-bytes",
+            filename=filename_override or "sample.mp4",
+            content_type="video/mp4",
+            metadata=metadata,
+        )
+
+    monkeypatch.setattr(media_router.yt_dlp_service, "download", fake_download)
+
+    response = client.post(
+        "/media/yt-dlp",
+        json={
+            "url": "https://example.com/video",
+            "response_format": "binary",
+            "filename": "custom.mp4",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.content == b"video-bytes"
+    assert response.headers["content-type"] == "video/mp4"
+    assert response.headers["Content-Disposition"].endswith("custom.mp4")
+
+    metadata_header = response.headers.get("X-YtDlp-Metadata")
+    assert metadata_header is not None
+    decoded = json.loads(base64.b64decode(metadata_header))
+    assert decoded["title"] == "Sample"
+
+
+def test_yt_dlp_failure_returns_error(client, monkeypatch):
+    def fake_extract(url: str, *, options):
+        raise media_router.YtDlpServiceError("boom")
+
+    monkeypatch.setattr(media_router.yt_dlp_service, "extract_info", fake_extract)
+
+    response = client.post(
+        "/media/yt-dlp",
+        json={"url": "https://example.com/video"},
+    )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "boom"
+


### PR DESCRIPTION
## Summary
- add a media router that wraps yt-dlp for metadata lookups and binary downloads
- expose automation-friendly headers and configuration options for the yt-dlp tool
- document the new media toolkit endpoint and update the service catalog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e052dd24608328956193245846beb9