### PR TITLE
Add image tooling endpoints for before-after and halations effects

### DIFF
--- a/tools-api/app/main.py
+++ b/tools-api/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
-from app.routers import docx, gdocs_parser, js_tools, media, parser
+from app.routers import docx, gdocs_parser, image_tools, js_tools, media, parser
 from app.extensions import local_queue_extension
 from app.utils.logger import logger
 from app.config import settings
@@ -50,6 +50,7 @@ app.include_router(docx.router)  # Already has /docx prefix
 app.include_router(gdocs_parser.router)
 app.include_router(js_tools.router)
 app.include_router(media.router)
+app.include_router(image_tools.router)
 local_queue_extension.register(app)
 
 

--- a/tools-api/app/routers/image_tools.py
+++ b/tools-api/app/routers/image_tools.py
@@ -1,0 +1,209 @@
+"""Image tooling endpoints inspired by FUT-Coding utilities."""
+from __future__ import annotations
+
+import base64
+import io
+import json
+from typing import Literal
+
+from fastapi import APIRouter, File, Form, HTTPException, Query, Response, UploadFile
+from PIL import Image
+from pydantic import BaseModel, Field
+
+from app.services.before_after_service import BeforeAfterError, BeforeAfterService
+from app.services.halations_service import HalationsError, HalationsService
+from app.utils.logger import logger
+
+router = APIRouter(prefix="/image-tools", tags=["image-tools"])
+
+
+class BeforeAfterResponse(BaseModel):
+    video_base64: str = Field(..., description="Base64 encoded MP4 animation.")
+    filename: str
+    content_type: str
+    metadata: dict
+    message: str | None = Field(
+        default=None,
+        description="Hint explaining how to customise the effect via request parameters.",
+    )
+
+
+class HalationsResponse(BaseModel):
+    image_base64: str = Field(..., description="Base64 encoded JPEG with halations effect applied.")
+    filename: str
+    content_type: str
+    metadata: dict
+    message: str | None = None
+
+
+@router.post(
+    "/before-after",
+    response_model=BeforeAfterResponse,
+    responses={
+        200: {
+            "content": {
+                "video/mp4": {"schema": {"type": "string", "format": "binary"}},
+            }
+        }
+    },
+)
+async def before_after_endpoint(
+    before_image: UploadFile = File(..., description="Image representing the 'before' state."),
+    after_image: UploadFile = File(..., description="Image representing the 'after' state."),
+    frame_width: int | None = Form(
+        default=None,
+        description="Optional output width. Defaults to the smaller width of the uploaded images.",
+    ),
+    frame_height: int | None = Form(
+        default=None,
+        description="Optional output height. Defaults to the smaller height of the uploaded images.",
+    ),
+    duration_seconds: float = Form(6.0, description="Clip duration in seconds."),
+    fps: int = Form(30, description="Frames per second."),
+    cycles: int = Form(2, description="Number of divider sweeps across the frame."),
+    line_thickness: int = Form(6, description="Thickness of the dividing line in pixels."),
+    add_text: bool = Form(False, description="Overlay promotional text at the bottom of the clip."),
+    overlay_text: str | None = Form(None, description="Text to render when add_text is true."),
+    response_format: Literal["json", "binary"] = Query(
+        "json",
+        description="Return JSON with base64 video (default) or binary MP4 stream.",
+    ),
+):
+    """Generate a before/after swipe animation."""
+
+    try:
+        before_bytes = await before_image.read()
+        after_bytes = await after_image.read()
+        if not before_bytes or not after_bytes:
+            raise HTTPException(status_code=400, detail="Both before and after images are required")
+
+        before = Image.open(io.BytesIO(before_bytes))
+        after = Image.open(io.BytesIO(after_bytes))
+
+        service = BeforeAfterService(
+            duration_seconds=duration_seconds,
+            fps=fps,
+            cycles=cycles,
+            line_thickness=line_thickness,
+            add_text=add_text,
+            overlay_text=overlay_text,
+        )
+
+        frame_size = None
+        if frame_width and frame_height:
+            frame_size = (frame_width, frame_height)
+
+        result = service.generate(before, after, frame_size=frame_size)
+    except BeforeAfterError as exc:
+        logger.error("Before/after generator failed: %s", exc)
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - Pillow parsing edge cases bubble up
+        logger.exception("Unexpected error generating before/after animation")
+        raise HTTPException(status_code=500, detail="Unable to generate animation") from exc
+
+    hint_message = None
+    if not any(
+        [
+            frame_width,
+            frame_height,
+            duration_seconds != 6.0,
+            fps != 30,
+            cycles != 2,
+            line_thickness != 6,
+            add_text,
+        ]
+    ):
+        hint_message = (
+            "Set form fields like frame_width, frame_height, duration_seconds, fps, cycles, or "
+            "line_thickness to customise the animation. Include add_text=true and overlay_text to append captions."
+        )
+
+    if response_format == "binary":
+        headers = {
+            "Content-Disposition": f"attachment; filename={result.filename}",
+            "X-Before-After-Metadata": base64.b64encode(
+                json.dumps(result.metadata, ensure_ascii=False).encode("utf-8")
+            ).decode("utf-8"),
+        }
+        if hint_message:
+            headers["X-Before-After-Hint"] = hint_message
+        return Response(content=result.content, media_type=result.content_type, headers=headers)
+
+    payload = base64.b64encode(result.content).decode("utf-8")
+    return BeforeAfterResponse(
+        video_base64=payload,
+        filename=result.filename,
+        content_type=result.content_type,
+        metadata=result.metadata,
+        message=hint_message,
+    )
+
+
+@router.post(
+    "/halations",
+    response_model=HalationsResponse,
+    responses={
+        200: {
+            "content": {
+                "image/jpeg": {"schema": {"type": "string", "format": "binary"}},
+            }
+        }
+    },
+)
+async def halations_endpoint(
+    image: UploadFile = File(..., description="Image to enhance using the halations glow effect."),
+    blur_amount: float = Form(10.0, description="Gaussian blur radius applied to the highlight mask."),
+    brightness_threshold: int = Form(200, description="Brightness cut-off for selecting highlights."),
+    strength: float = Form(50.0, description="Intensity of the glow overlay."),
+    response_format: Literal["json", "binary"] = Query(
+        "json",
+        description="Return JSON (default) or binary JPEG output.",
+    ),
+):
+    """Apply the halations glow effect to an image."""
+
+    try:
+        image_bytes = await image.read()
+        if not image_bytes:
+            raise HTTPException(status_code=400, detail="Image upload is required")
+
+        pil_image = Image.open(io.BytesIO(image_bytes))
+        service = HalationsService(
+            blur_amount=blur_amount,
+            brightness_threshold=brightness_threshold,
+            strength=strength,
+        )
+        result = service.apply(pil_image)
+    except HalationsError as exc:
+        logger.error("Halations effect failed: %s", exc)
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - Pillow parsing edge cases bubble up
+        logger.exception("Unexpected error generating halations image")
+        raise HTTPException(status_code=500, detail="Unable to process image") from exc
+
+    hint_message = None
+    if blur_amount == 10.0 and brightness_threshold == 200 and strength == 50.0:
+        hint_message = (
+            "Adjust blur_amount, brightness_threshold, or strength form fields to fine tune the halations glow."
+        )
+
+    if response_format == "binary":
+        headers = {
+            "Content-Disposition": f"attachment; filename={result.filename}",
+            "X-Halations-Metadata": base64.b64encode(
+                json.dumps(result.metadata, ensure_ascii=False).encode("utf-8")
+            ).decode("utf-8"),
+        }
+        if hint_message:
+            headers["X-Halations-Hint"] = hint_message
+        return Response(content=result.content, media_type=result.content_type, headers=headers)
+
+    payload = base64.b64encode(result.content).decode("utf-8")
+    return HalationsResponse(
+        image_base64=payload,
+        filename=result.filename,
+        content_type=result.content_type,
+        metadata=result.metadata,
+        message=hint_message,
+    )
+

--- a/tools-api/app/services/before_after_service.py
+++ b/tools-api/app/services/before_after_service.py
@@ -1,0 +1,204 @@
+"""Before/after animation generator inspired by FUT-Coding/beforeandafter."""
+from __future__ import annotations
+
+import math
+import tempfile
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+import imageio
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont, ImageOps
+
+
+class BeforeAfterError(RuntimeError):
+    """Raised when a before/after animation cannot be produced."""
+
+
+@dataclass
+class BeforeAfterResult:
+    """Binary animation payload returned by :class:`BeforeAfterService`."""
+
+    content: bytes
+    content_type: str
+    filename: str
+    metadata: Dict[str, int | float | str | bool]
+
+
+class BeforeAfterService:
+    """Create looping swipe animations from two images.
+
+    The implementation ports the core behaviour of
+    https://github.com/FUTC-Coding/beforeandafter to Python so the effect can be
+    consumed via the Tools API. The animation mimics the JavaScript version by
+    animating a divider line across the frame twice using a cosine easing
+    function so the clip loops seamlessly.
+    """
+
+    def __init__(
+        self,
+        *,
+        duration_seconds: float = 6.0,
+        fps: int = 30,
+        cycles: int = 2,
+        line_thickness: int = 6,
+        add_text: bool = False,
+        overlay_text: str | None = None,
+        text_baseline_offset: int = 120,
+        text_fill: Tuple[int, int, int] = (40, 40, 40),
+    ) -> None:
+        if duration_seconds <= 0:
+            raise BeforeAfterError("Duration must be greater than zero")
+        if fps <= 0:
+            raise BeforeAfterError("FPS must be greater than zero")
+        if cycles <= 0:
+            raise BeforeAfterError("Cycles must be a positive integer")
+
+        self.duration_seconds = float(duration_seconds)
+        self.fps = int(fps)
+        self.cycles = int(cycles)
+        self.line_thickness = max(1, int(line_thickness))
+        self.add_text = bool(add_text)
+        self.overlay_text = overlay_text or ""
+        self.text_baseline_offset = max(0, int(text_baseline_offset))
+        self.text_fill = tuple(text_fill)
+
+    def generate(
+        self,
+        before_image: Image.Image,
+        after_image: Image.Image,
+        *,
+        frame_size: Tuple[int, int] | None = None,
+    ) -> BeforeAfterResult:
+        if before_image.mode not in ("RGB", "RGBA"):
+            before_image = before_image.convert("RGB")
+        if after_image.mode not in ("RGB", "RGBA"):
+            after_image = after_image.convert("RGB")
+
+        width, height = self._resolve_frame_size(before_image.size, after_image.size, frame_size)
+        before = ImageOps.fit(before_image, (width, height), Image.Resampling.LANCZOS)
+        after = ImageOps.fit(after_image, (width, height), Image.Resampling.LANCZOS)
+
+        frames = list(self._build_frames(before, after))
+
+        metadata = {
+            "width": width,
+            "height": height,
+            "fps": self.fps,
+            "duration_seconds": self.duration_seconds,
+            "cycles": self.cycles,
+            "line_thickness": self.line_thickness,
+            "add_text": self.add_text,
+        }
+
+        # imageio uses numpy arrays, so convert the PIL frames.
+        np_frames = [np.asarray(frame) for frame in frames]
+
+        temp_file = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
+        temp_file.close()
+
+        try:
+            with imageio.get_writer(
+                temp_file.name,
+                fps=self.fps,
+                codec="libx264",
+                quality=8,
+                macro_block_size=None,
+            ) as writer:
+                for array in np_frames:
+                    writer.append_data(array)
+            content = Path(temp_file.name).read_bytes()
+        except (RuntimeError, ValueError, OSError) as exc:  # pragma: no cover - depends on ffmpeg availability
+            raise BeforeAfterError("Failed to encode animation with ffmpeg") from exc
+        finally:
+            try:
+                Path(temp_file.name).unlink(missing_ok=True)
+            except OSError:
+                pass
+
+        filename = f"before-after-{uuid.uuid4().hex[:8]}.mp4"
+        return BeforeAfterResult(
+            content=content,
+            content_type="video/mp4",
+            filename=filename,
+            metadata=metadata,
+        )
+
+    def _build_frames(self, before: Image.Image, after: Image.Image) -> Iterable[Image.Image]:
+        total_frames = max(2, int(self.fps * self.duration_seconds))
+        width, height = before.size
+
+        for index in range(total_frames):
+            normalized_time = index / (total_frames - 1)
+            progress = (1 - math.cos(normalized_time * math.pi * self.cycles)) / 2
+            divider_x = int(progress * width)
+
+            frame = before.copy()
+            mask = Image.new("L", before.size, 0)
+            mask_draw = ImageDraw.Draw(mask)
+            mask_draw.rectangle([divider_x, 0, width, height], fill=255)
+            frame.paste(after, mask=mask)
+
+            draw = ImageDraw.Draw(frame)
+            self._draw_divider(draw, divider_x, height)
+
+            if self.add_text and self.overlay_text:
+                self._draw_overlay_text(draw, width, height)
+
+            yield frame
+
+    def _draw_divider(self, draw: ImageDraw.ImageDraw, x_position: int, height: int) -> None:
+        outline_color = (20, 20, 20)
+        main_color = (255, 255, 255)
+
+        draw.line(
+            [(x_position, -10), (x_position, height + 10)],
+            fill=outline_color,
+            width=self.line_thickness + 4,
+        )
+        draw.line(
+            [(x_position, -10), (x_position, height + 10)],
+            fill=main_color,
+            width=self.line_thickness,
+        )
+
+    def _draw_overlay_text(self, draw: ImageDraw.ImageDraw, width: int, height: int) -> None:
+        try:
+            font = ImageFont.truetype("arial.ttf", size=max(24, width // 18))
+        except OSError:
+            font = ImageFont.load_default()
+
+        text = self.overlay_text
+        text_bbox = draw.textbbox((0, 0), text, font=font)
+        text_width = text_bbox[2] - text_bbox[0]
+        x_position = (width - text_width) // 2
+        y_position = max(0, height - self.text_baseline_offset)
+
+        draw.text(
+            (x_position, y_position),
+            text,
+            font=font,
+            fill=self.text_fill,
+        )
+
+    @staticmethod
+    def _resolve_frame_size(
+        before_size: Tuple[int, int],
+        after_size: Tuple[int, int],
+        requested: Tuple[int, int] | None,
+    ) -> Tuple[int, int]:
+        if requested:
+            width, height = requested
+            if width <= 0 or height <= 0:
+                raise BeforeAfterError("Requested frame size must be positive")
+            return int(width), int(height)
+
+        # Default to the smaller shared dimensions so we never upscale drastically.
+        width = min(before_size[0], after_size[0])
+        height = min(before_size[1], after_size[1])
+        if width <= 0 or height <= 0:
+            raise BeforeAfterError("Input images must have positive dimensions")
+        return width, height
+

--- a/tools-api/app/services/halations_service.py
+++ b/tools-api/app/services/halations_service.py
@@ -1,0 +1,90 @@
+"""Port of FUTC-Coding/halations image glow effect."""
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+from PIL import Image, ImageFilter
+
+
+class HalationsError(RuntimeError):
+    """Raised when an image cannot be processed with the halations effect."""
+
+
+@dataclass
+class HalationsResult:
+    """Binary payload for the generated halations image."""
+
+    content: bytes
+    filename: str
+    content_type: str
+    metadata: Dict[str, int | float]
+
+
+class HalationsService:
+    """Apply a highlight glow reminiscent of the halations web tool."""
+
+    def __init__(
+        self,
+        *,
+        blur_amount: float = 10.0,
+        brightness_threshold: int = 200,
+        strength: float = 50.0,
+    ) -> None:
+        if blur_amount < 0:
+            raise HalationsError("Blur amount must be non-negative")
+        if brightness_threshold < 0 or brightness_threshold > 255:
+            raise HalationsError("Brightness threshold must be between 0 and 255")
+
+        self.blur_amount = float(blur_amount)
+        self.brightness_threshold = int(brightness_threshold)
+        self.strength = float(strength)
+
+    def apply(self, image: Image.Image) -> HalationsResult:
+        if image.mode != "RGB":
+            image = image.convert("RGB")
+
+        original = np.asarray(image, dtype=np.float32)
+        brightness = original.mean(axis=2)
+
+        mask = (brightness >= self.brightness_threshold).astype(np.float32)
+        mask_image = Image.fromarray((mask * 255).astype(np.uint8))
+
+        if self.blur_amount > 0:
+            mask_image = mask_image.filter(ImageFilter.GaussianBlur(radius=self.blur_amount))
+
+        blurred_mask = np.asarray(mask_image, dtype=np.float32) / 255.0
+
+        overlay = np.zeros_like(original)
+        overlay[..., 0] = np.clip(blurred_mask * 255 + self.strength, 0, 255)
+
+        result = self._screen_blend(original, overlay)
+
+        buffer = io.BytesIO()
+        Image.fromarray(result.astype(np.uint8)).save(buffer, format="JPEG", quality=95)
+
+        metadata = {
+            "width": int(image.width),
+            "height": int(image.height),
+            "blur_amount": self.blur_amount,
+            "brightness_threshold": self.brightness_threshold,
+            "strength": self.strength,
+        }
+
+        filename = "halations-result.jpg"
+        return HalationsResult(
+            content=buffer.getvalue(),
+            filename=filename,
+            content_type="image/jpeg",
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _screen_blend(base: np.ndarray, overlay: np.ndarray) -> np.ndarray:
+        base_norm = base / 255.0
+        overlay_norm = overlay / 255.0
+        blended = 1 - (1 - base_norm) * (1 - overlay_norm)
+        return np.clip(blended * 255.0, 0, 255)
+

--- a/tools-api/docs/service_catalog.yaml
+++ b/tools-api/docs/service_catalog.yaml
@@ -164,9 +164,78 @@
               "error": "string – Present when status=failed."
             }
           }
+    }
+  ]
+},
+{
+  "name": "Image Effects",
+  "summary": "Expose the Before & After swipe generator and Halations glow filter via REST APIs.",
+  "docs_url": "http://localhost:8000/docs#/image-tools",
+  "endpoints": [
+    {
+      "method": "POST",
+      "path": "/image-tools/before-after",
+      "headline": "Before ↔ After Animation",
+      "tagline": "Create looping swipe videos from two images – straight from your automations.",
+      "description": "Uploads two images and returns a base64 MP4 (or binary stream) with a sliding divider that mimics the FUT-Coding before-and-after tool.",
+      "request": {
+        "content_type": "multipart/form-data",
+        "fields": {
+          "before_image": "file – Image showing the 'before' state.",
+          "after_image": "file – Image showing the 'after' state.",
+          "frame_width": "int (optional) – Override output width.",
+          "frame_height": "int (optional) – Override output height.",
+          "duration_seconds": "float (optional) – Clip duration (default 6s).",
+          "fps": "int (optional) – Frame rate (default 30).",
+          "cycles": "int (optional) – Number of divider passes (default 2).",
+          "line_thickness": "int (optional) – Divider thickness (default 6px).",
+          "add_text": "bool (optional) – Enable overlay text.",
+          "overlay_text": "string (optional) – Text content rendered when add_text is true.",
+          "response_format": "query: json|binary – Choose JSON (base64) or MP4 stream."
+        },
+        "notes": [
+          "When no optional parameters are supplied the API responds with a hint explaining customisation options."
+        ]
+      },
+      "response": {
+        "content_type": "application/json",
+        "fields": {
+          "video_base64": "string – Base64 encoded MP4 clip.",
+          "metadata": "object – Echoes dimensions, fps, duration, etc.",
+          "message": "string – Optional hint about available parameters."
         }
-      ]
+      }
     },
+    {
+      "method": "POST",
+      "path": "/image-tools/halations",
+      "headline": "Halations Glow",
+      "tagline": "Wrap the FUT-Coding halations image filter inside Tools API.",
+      "description": "Applies a brightness-driven glow effect inspired by the halations open-source project.",
+      "request": {
+        "content_type": "multipart/form-data",
+        "fields": {
+          "image": "file – Source image.",
+          "blur_amount": "float (optional) – Blur radius for the glow mask (default 10).",
+          "brightness_threshold": "int (optional) – Highlight threshold (default 200).",
+          "strength": "float (optional) – Intensity of the overlay (default 50).",
+          "response_format": "query: json|binary – Choose JSON (base64) or JPEG stream."
+        },
+        "notes": [
+          "Default requests include a hint about tweaking blur_amount, brightness_threshold, and strength."
+        ]
+      },
+      "response": {
+        "content_type": "application/json",
+        "fields": {
+          "image_base64": "string – Base64 encoded JPEG with glow applied.",
+          "metadata": "object – Echoes dimensions and parameter values.",
+          "message": "string – Optional hint about available parameters."
+        }
+      }
+    }
+  ]
+},
     {
       "name": "Google Docs JSON Parser",
       "summary": "Pull plain text, links, and image references out of Google Docs JSON exports for downstream automations.",

--- a/tools-api/requirements.txt
+++ b/tools-api/requirements.txt
@@ -5,6 +5,9 @@ markdown
 pydantic
 pystray
 pillow
+numpy
+imageio
+imageio-ffmpeg
 pyyaml
 python-docx
 python-dotenv

--- a/tools-api/tests/test_image_tools.py
+++ b/tools-api/tests/test_image_tools.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import base64
+import io
+
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from app.main import app
+
+
+def _create_image_bytes(color: tuple[int, int, int], size: tuple[int, int] = (64, 64)) -> bytes:
+    image = Image.new("RGB", size, color=color)
+    buffer = io.BytesIO()
+    image.save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def test_before_after_default_message():
+    client = TestClient(app)
+
+    before_bytes = _create_image_bytes((255, 0, 0))
+    after_bytes = _create_image_bytes((0, 0, 255))
+
+    response = client.post(
+        "/image-tools/before-after",
+        files={
+            "before_image": ("before.jpg", before_bytes, "image/jpeg"),
+            "after_image": ("after.jpg", after_bytes, "image/jpeg"),
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["content_type"] == "video/mp4"
+    assert payload["message"] is not None
+
+    video_bytes = base64.b64decode(payload["video_base64"])
+    # Minimal assurance that we produced an MP4 container.
+    assert video_bytes[4:8] == b"ftyp"
+
+
+def test_before_after_binary_headers():
+    client = TestClient(app)
+
+    before_bytes = _create_image_bytes((255, 255, 255))
+    after_bytes = _create_image_bytes((0, 0, 0))
+
+    response = client.post(
+        "/image-tools/before-after",
+        files={
+            "before_image": ("before.jpg", before_bytes, "image/jpeg"),
+            "after_image": ("after.jpg", after_bytes, "image/jpeg"),
+        },
+        data={
+            "duration_seconds": "2",
+            "fps": "15",
+            "line_thickness": "4",
+        },
+        params={"response_format": "binary"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "video/mp4"
+    assert "X-Before-After-Metadata" in response.headers
+    # Custom parameters suppress the hint header.
+    assert "X-Before-After-Hint" not in response.headers
+
+
+def test_halations_default_hint():
+    client = TestClient(app)
+
+    image_bytes = _create_image_bytes((200, 200, 200))
+
+    response = client.post(
+        "/image-tools/halations",
+        files={"image": ("input.jpg", image_bytes, "image/jpeg")},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["content_type"] == "image/jpeg"
+    assert payload["message"] is not None
+
+    processed = base64.b64decode(payload["image_base64"])
+    assert processed.startswith(b"\xff\xd8\xff")  # JPEG magic number
+
+
+def test_halations_binary_metadata():
+    client = TestClient(app)
+
+    image_bytes = _create_image_bytes((180, 180, 180))
+
+    response = client.post(
+        "/image-tools/halations",
+        files={"image": ("input.jpg", image_bytes, "image/jpeg")},
+        data={
+            "blur_amount": "5",
+            "brightness_threshold": "150",
+            "strength": "80",
+        },
+        params={"response_format": "binary"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/jpeg"
+    assert "X-Halations-Metadata" in response.headers
+    assert "X-Halations-Hint" not in response.headers


### PR DESCRIPTION
## Summary
- add new `/image-tools` router that wraps the FUT-Coding before/after animation generator and halations glow filter
- implement Python service ports for both tools and expose hint messaging plus binary streaming support
- document the new endpoints in the service catalog and pull in image/video dependencies and tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e0f47b8cb0832898c7c2f85bf0b4d2