### PR TITLE
Add browser-based Tools API Studio and preflight checks

### DIFF
--- a/tools-api/app/runtime/preflight.py
+++ b/tools-api/app/runtime/preflight.py
@@ -1,0 +1,34 @@
+"""Pre-flight helpers to ensure optional toolchains are ready before serving traffic."""
+from __future__ import annotations
+
+from app.services.js_tool_service import JavaScriptToolError, ensure_panosplitter_ready
+from app.services.yt_dlp_service import YtDlpServiceError, ensure_media_tools_ready
+from app.utils.logger import logger
+
+
+def prepare_environment() -> None:
+    """Run dependency checks for bundled tools.
+
+    The routine logs warnings instead of raising so the API can still launch when optional
+    runtimes (Node.js, yt-dlp) are unavailable. This mirrors the UX of the original desktop
+    control centre where optional features degrade gracefully.
+    """
+
+    logger.info("Performing Tools API pre-flight checks…")
+
+    try:
+        ensure_panosplitter_ready()
+        logger.info("✅ Panosplitter is ready for JavaScript-powered slicing.")
+    except JavaScriptToolError as exc:
+        logger.warning("⚠️ Panosplitter unavailable: %s", exc)
+
+    try:
+        ensure_media_tools_ready()
+        logger.info("✅ yt-dlp dependency detected.")
+    except YtDlpServiceError as exc:
+        logger.warning("⚠️ Media toolkit unavailable: %s", exc)
+
+    logger.info("Pre-flight checks complete.")
+
+
+__all__ = ["prepare_environment"]

--- a/tools-api/app/services/js_tool_service.py
+++ b/tools-api/app/services/js_tool_service.py
@@ -79,6 +79,20 @@ def _ensure_dependencies(tool_dir: Path) -> None:
             raise JavaScriptToolError("Failed to install JavaScript tool dependencies")
 
 
+def ensure_panosplitter_ready() -> None:
+    """Pre-flight helper to make sure the Node-based panosplitter is usable."""
+
+    _ensure_node_available()
+
+    tool_dir = Path(__file__).resolve().parents[2] / "js_tools" / "panosplitter"
+    cli_path = tool_dir / "cli.js"
+    if not cli_path.exists():
+        raise JavaScriptToolError("Panosplitter CLI script not found")
+
+    _ensure_dependencies(tool_dir)
+    logger.info("Panosplitter dependencies are ready at %s", tool_dir)
+
+
 def _parse_cli_output(stdout: str) -> PanosplitterResult:
     """Parse the JSON payload emitted by the Node.js CLI."""
 

--- a/tools-api/app/services/yt_dlp_service.py
+++ b/tools-api/app/services/yt_dlp_service.py
@@ -39,6 +39,13 @@ def _ensure_yt_dlp() -> Any:
     return yt_dlp
 
 
+def ensure_media_tools_ready() -> None:
+    """Confirm that yt-dlp is importable for media tooling."""
+
+    _ensure_yt_dlp()
+    logger.info("yt-dlp dependency is available")
+
+
 class YtDlpService:
     """Thin wrapper around yt-dlp with opinionated defaults."""
 

--- a/tools-api/app/static/css/studio.css
+++ b/tools-api/app/static/css/studio.css
@@ -1,0 +1,525 @@
+:root {
+    color-scheme: dark;
+    --bg: #05070d;
+    --sidebar: #0b1020;
+    --panel: #121a2c;
+    --card: #17233a;
+    --border: #1f2d4a;
+    --accent: #4f8bff;
+    --accent-strong: #2f6aff;
+    --text: #f8fbff;
+    --muted: #8a9bbd;
+    --success: #34d399;
+    --warning: #facc15;
+    --danger: #f87171;
+    --radius-lg: 20px;
+    --radius-md: 12px;
+    --radius-sm: 8px;
+    --shadow: 0 30px 60px rgba(4, 8, 20, 0.45);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: radial-gradient(circle at top left, rgba(79, 139, 255, 0.2), transparent 45%),
+        radial-gradient(circle at bottom right, rgba(52, 211, 153, 0.12), transparent 40%),
+        var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+}
+
+.app-shell {
+    display: grid;
+    grid-template-columns: 320px 1fr;
+    min-height: 100vh;
+}
+
+.sidebar {
+    background: linear-gradient(180deg, rgba(18, 25, 46, 0.96) 0%, rgba(7, 11, 24, 0.98) 100%);
+    border-right: 1px solid rgba(255, 255, 255, 0.05);
+    padding: 32px 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    position: sticky;
+    top: 0;
+    height: 100vh;
+}
+
+.sidebar__brand {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.sidebar__logo {
+    width: 54px;
+    height: 54px;
+    display: grid;
+    place-items: center;
+    background: radial-gradient(circle at 30% 20%, rgba(79, 139, 255, 0.45), transparent), rgba(79, 139, 255, 0.12);
+    border-radius: var(--radius-lg);
+    font-size: 24px;
+    filter: drop-shadow(0 10px 20px rgba(79, 139, 255, 0.35));
+}
+
+.sidebar__brand h1 {
+    margin: 0;
+    font-size: 1.4rem;
+}
+
+.sidebar__subtitle {
+    margin: 4px 0 0;
+    font-size: 0.85rem;
+    color: var(--muted);
+}
+
+.sidebar__nav {
+    display: grid;
+    gap: 12px;
+}
+
+.nav-link {
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--muted);
+    font-size: 0.95rem;
+    font-weight: 500;
+    text-align: left;
+    padding: 12px 14px;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.nav-link:hover {
+    background: rgba(79, 139, 255, 0.12);
+    color: var(--text);
+    border-color: rgba(79, 139, 255, 0.35);
+    transform: translateX(4px);
+}
+
+.nav-link.active {
+    background: rgba(79, 139, 255, 0.2);
+    border-color: rgba(79, 139, 255, 0.45);
+    color: var(--text);
+    box-shadow: 0 12px 30px rgba(79, 139, 255, 0.2);
+}
+
+.sidebar__footer {
+    margin-top: auto;
+    display: grid;
+    gap: 12px;
+}
+
+.primary-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+    color: #ffffff;
+    padding: 12px 16px;
+    border-radius: var(--radius-md);
+    border: none;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 40px rgba(79, 139, 255, 0.3);
+}
+
+.primary-btn:disabled {
+    background: rgba(79, 139, 255, 0.25);
+    cursor: not-allowed;
+}
+
+.sidebar__hint {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--muted);
+}
+
+.content {
+    padding: 48px 48px 96px;
+    display: grid;
+    gap: 40px;
+}
+
+.panel {
+    background: linear-gradient(180deg, rgba(17, 26, 44, 0.9) 0%, rgba(12, 18, 32, 0.95) 100%);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    box-shadow: var(--shadow);
+    overflow: hidden;
+}
+
+.panel__header {
+    padding: 32px 36px 0;
+}
+
+.panel__header h2 {
+    margin: 0 0 12px;
+    font-size: 1.8rem;
+}
+
+.panel__header p {
+    margin: 0;
+    color: var(--muted);
+}
+
+.panel__body {
+    padding: 32px 36px 36px;
+    display: grid;
+    gap: 24px;
+}
+
+.grid.two-column {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.card {
+    background: rgba(11, 18, 32, 0.85);
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    padding: 24px;
+    display: grid;
+    gap: 16px;
+    position: relative;
+    overflow: hidden;
+}
+
+.card::after {
+    content: "";
+    position: absolute;
+    inset: -60% -30% auto;
+    height: 120%;
+    background: radial-gradient(circle, rgba(79, 139, 255, 0.12) 0%, transparent 70%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+}
+
+.card:hover::after {
+    opacity: 1;
+}
+
+.card h3 {
+    margin: 0;
+}
+
+.card span.badge {
+    background: rgba(79, 139, 255, 0.2);
+    color: var(--text);
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 0.75rem;
+}
+
+.card.span-two {
+    grid-column: span 2;
+}
+
+.form-header p {
+    margin: 4px 0 0;
+}
+
+label {
+    font-weight: 500;
+    font-size: 0.9rem;
+}
+
+input[type="text"],
+input[type="url"],
+input[type="number"],
+textarea,
+input[type="search"],
+input[type="file"] {
+    width: 100%;
+    padding: 10px 12px;
+    background: rgba(9, 15, 28, 0.75);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    font-family: inherit;
+    font-size: 0.95rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type="text"]:focus,
+input[type="url"]:focus,
+input[type="number"]:focus,
+textarea:focus,
+input[type="search"]:focus,
+input[type="file"]:focus {
+    outline: none;
+    border-color: rgba(79, 139, 255, 0.6);
+    box-shadow: 0 0 0 4px rgba(79, 139, 255, 0.15);
+}
+
+textarea {
+    resize: vertical;
+}
+
+.slider-group {
+    display: grid;
+    gap: 8px;
+}
+
+.slider-group input[type="range"] {
+    width: 100%;
+}
+
+.form-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 12px;
+}
+
+.checkbox {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.9rem;
+    color: var(--muted);
+}
+
+.checkbox input {
+    width: auto;
+}
+
+.result-panel {
+    background: rgba(6, 10, 20, 0.85);
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    padding: 24px;
+    min-height: 120px;
+    display: grid;
+    gap: 16px;
+}
+
+.result-panel h4 {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.result-panel .result-group {
+    display: grid;
+    gap: 12px;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: var(--radius-sm);
+    padding: 16px;
+}
+
+.result-panel pre {
+    background: rgba(9, 14, 26, 0.95);
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    padding: 16px;
+    overflow: auto;
+    max-height: 360px;
+    font-size: 0.85rem;
+}
+
+.result-panel p {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.result-panel p strong {
+    color: var(--text);
+}
+
+.result-panel img,
+.result-panel video {
+    width: 100%;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    max-height: 340px;
+    object-fit: contain;
+    background: rgba(0, 0, 0, 0.25);
+}
+
+.slice-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 12px;
+}
+
+.slice-grid img {
+    width: 100%;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(0, 0, 0, 0.35);
+}
+
+.result-panel .download-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(79, 139, 255, 0.15);
+    color: var(--text);
+    border-radius: 999px;
+    padding: 8px 14px;
+    text-decoration: none;
+    font-size: 0.85rem;
+    transition: background 0.2s ease;
+}
+
+.result-panel .download-link:hover {
+    background: rgba(79, 139, 255, 0.3);
+}
+
+.meta-grid {
+    display: grid;
+    gap: 10px;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.meta-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: var(--radius-sm);
+    padding: 12px;
+    display: grid;
+    gap: 6px;
+}
+
+.meta-item span.label {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+
+.meta-item span.value {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.pill-group {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.pill {
+    padding: 8px 14px;
+    border-radius: 999px;
+    background: rgba(79, 139, 255, 0.15);
+    border: 1px solid rgba(79, 139, 255, 0.3);
+    font-size: 0.85rem;
+    color: var(--text);
+}
+
+.endpoint-search {
+    display: grid;
+    gap: 8px;
+}
+
+.endpoint-list {
+    display: grid;
+    gap: 12px;
+    max-height: 260px;
+    overflow: auto;
+}
+
+.endpoint-group {
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: var(--radius-sm);
+    padding: 12px;
+    background: rgba(10, 15, 28, 0.8);
+}
+
+.endpoint-group h4 {
+    margin: 0 0 10px;
+    font-size: 0.95rem;
+}
+
+.endpoint-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    background: rgba(255, 255, 255, 0.03);
+    font-size: 0.85rem;
+}
+
+.endpoint-item span.method {
+    font-weight: 600;
+    color: var(--success);
+}
+
+.endpoint-item span.path {
+    font-family: "Fira Code", "SFMono-Regular", Menlo, monospace;
+}
+
+.toast {
+    position: fixed;
+    bottom: 32px;
+    right: 32px;
+    background: rgba(7, 12, 24, 0.95);
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(79, 139, 255, 0.35);
+    padding: 16px 20px;
+    box-shadow: 0 20px 40px rgba(4, 8, 20, 0.5);
+    max-width: 320px;
+    font-size: 0.95rem;
+    color: var(--text);
+    z-index: 100;
+}
+
+.toast.success {
+    border-color: rgba(52, 211, 153, 0.4);
+}
+
+.toast.error {
+    border-color: rgba(248, 113, 113, 0.5);
+}
+
+.muted {
+    color: var(--muted);
+}
+
+@media (max-width: 1100px) {
+    .app-shell {
+        grid-template-columns: 1fr;
+    }
+
+    .sidebar {
+        position: static;
+        height: auto;
+        border-right: none;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    }
+}
+
+@media (max-width: 720px) {
+    .content {
+        padding: 32px 20px 80px;
+    }
+
+    .panel__body,
+    .panel__header {
+        padding-left: 20px;
+        padding-right: 20px;
+    }
+
+    .card.span-two {
+        grid-column: span 1;
+    }
+}

--- a/tools-api/app/static/js/studio.js
+++ b/tools-api/app/static/js/studio.js
@@ -1,0 +1,764 @@
+const config = window.__STUDIO_CONFIG__ || {};
+const OPENAPI_URL = config.openapiUrl || '/openapi.json';
+const toastState = { timer: null };
+let endpointCatalogue = null;
+
+function init() {
+    setupNavigation();
+    setupSectionObserver();
+    initialiseResultPanels();
+    setupHalationsControls();
+    setupBeforeAfterControls();
+    setupForms();
+    loadEndpointCatalogue();
+}
+
+function setupNavigation() {
+    const navLinks = document.querySelectorAll('.nav-link');
+    navLinks.forEach((link) => {
+        link.addEventListener('click', () => {
+            const targetId = link.dataset.section;
+            const target = document.getElementById(targetId);
+            if (target) {
+                target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+            navLinks.forEach((btn) => btn.classList.toggle('active', btn === link));
+        });
+    });
+}
+
+function setupSectionObserver() {
+    const sections = document.querySelectorAll('main .panel');
+    const navLookup = new Map();
+    document.querySelectorAll('.nav-link').forEach((link) => {
+        navLookup.set(link.dataset.section, link);
+    });
+
+    if (!('IntersectionObserver' in window)) {
+        return;
+    }
+
+    const observer = new IntersectionObserver(
+        (entries) => {
+            const visible = entries
+                .filter((entry) => entry.isIntersecting)
+                .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+            if (visible.length) {
+                const sectionId = visible[0].target.id;
+                navLookup.forEach((btn, id) => {
+                    btn.classList.toggle('active', id === sectionId);
+                });
+            }
+        },
+        { threshold: 0.35 }
+    );
+
+    sections.forEach((section) => observer.observe(section));
+}
+
+function initialiseResultPanels() {
+    const placeholders = {
+        'parser-results': 'Run a parser request to inspect Docs operations.',
+        'docx-results': 'Upload a DOCX file to extract text.',
+        'image-results': 'Generate a glow or before/after clip to preview the output.',
+        'js-results': 'Split a panorama to see generated slices and download bundles.',
+        'media-results': 'Inspect a media URL with yt-dlp to reveal metadata or downloads.'
+    };
+
+    Object.entries(placeholders).forEach(([id, message]) => {
+        const container = document.getElementById(id);
+        if (container && !container.children.length) {
+            const paragraph = document.createElement('p');
+            paragraph.textContent = message;
+            container.appendChild(paragraph);
+        }
+    });
+}
+
+function setupHalationsControls() {
+    const blurSlider = document.getElementById('blur-slider');
+    const blurValue = document.getElementById('blur-value');
+    const brightnessSlider = document.getElementById('brightness-slider');
+    const brightnessValue = document.getElementById('brightness-value');
+    const strengthSlider = document.getElementById('strength-slider');
+    const strengthValue = document.getElementById('strength-value');
+
+    if (blurSlider && blurValue) {
+        blurValue.textContent = blurSlider.value;
+        blurSlider.addEventListener('input', () => {
+            blurValue.textContent = blurSlider.value;
+        });
+    }
+
+    if (brightnessSlider && brightnessValue) {
+        brightnessValue.textContent = brightnessSlider.value;
+        brightnessSlider.addEventListener('input', () => {
+            brightnessValue.textContent = brightnessSlider.value;
+        });
+    }
+
+    if (strengthSlider && strengthValue) {
+        strengthValue.textContent = strengthSlider.value;
+        strengthSlider.addEventListener('input', () => {
+            strengthValue.textContent = strengthSlider.value;
+        });
+    }
+}
+
+function setupBeforeAfterControls() {
+    const toggle = document.getElementById('before-after-text-toggle');
+    const textarea = document.getElementById('before-after-text');
+    if (!toggle || !textarea) {
+        return;
+    }
+
+    toggle.addEventListener('change', () => {
+        textarea.style.display = toggle.checked ? 'block' : 'none';
+    });
+}
+
+function setupForms() {
+    setupParserForms();
+    setupDocxForm();
+    setupHalationsForm();
+    setupBeforeAfterForm();
+    setupPanosplitterForm();
+    setupYtDlpForm();
+}
+
+function setupParserForms() {
+    attachSubmit('html-parse-form', async (form) => {
+        const html = form.querySelector('textarea[name="html"]').value.trim();
+        if (!html) {
+            throw new Error('Provide HTML to parse.');
+        }
+        const result = await postJSON('/parse/html', { html });
+        setResult('parser-results', [
+            createResultGroup('HTML → Requests', [createPre(result.requests)])
+        ]);
+        showToast('HTML parsed successfully.');
+    });
+
+    attachSubmit('markdown-parse-form', async (form) => {
+        const markdown = form.querySelector('textarea[name="markdown"]').value.trim();
+        if (!markdown) {
+            throw new Error('Provide Markdown to parse.');
+        }
+        const result = await postJSON('/parse/markdown', { markdown });
+        setResult('parser-results', [
+            createResultGroup('Markdown → Requests', [createPre(result.requests)])
+        ]);
+        showToast('Markdown parsed successfully.');
+    });
+
+    attachSubmit('docs-html-form', async (form) => {
+        const html = form.querySelector('textarea[name="html"]').value.trim();
+        if (!html) {
+            throw new Error('Provide HTML to convert.');
+        }
+        const result = await postJSON('/parse/docs/html', { html });
+        setResult('parser-results', [
+            createResultGroup('Docs BatchUpdate (HTML)', [createPre(result.requests)])
+        ]);
+        showToast('Docs requests generated from HTML.');
+    });
+
+    attachSubmit('docs-markdown-form', async (form) => {
+        const markdown = form.querySelector('textarea[name="markdown"]').value.trim();
+        if (!markdown) {
+            throw new Error('Provide Markdown to convert.');
+        }
+        const result = await postJSON('/parse/docs/markdown', { markdown });
+        setResult('parser-results', [
+            createResultGroup('Docs BatchUpdate (Markdown)', [createPre(result.requests)])
+        ]);
+        showToast('Docs requests generated from Markdown.');
+    });
+}
+
+function setupDocxForm() {
+    attachSubmit('docx-parse-form', async (form) => {
+        const fileInput = document.getElementById('docx-file');
+        const file = fileInput && fileInput.files ? fileInput.files[0] : null;
+        if (!file) {
+            throw new Error('Select a DOCX file first.');
+        }
+
+        const response = await fetch('/docx/parse', {
+            method: 'POST',
+            headers: {
+                'Content-Type': file.type || 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+            },
+            body: file
+        });
+        const result = await parseResponse(response);
+        setResult('docx-results', [
+            createResultGroup('Extracted Text', [createPre(result.text || '')]),
+            createResultGroup('Metadata', [createMetaGrid({
+                'File name': file.name,
+                'Content type': result.content_type,
+                'Size (bytes)': result.size_bytes
+            })])
+        ]);
+        showToast('DOCX parsed successfully.');
+    });
+}
+
+function setupHalationsForm() {
+    attachSubmit('halations-form', async () => {
+        const imageInput = document.getElementById('halations-image');
+        const file = imageInput && imageInput.files ? imageInput.files[0] : null;
+        if (!file) {
+            throw new Error('Choose an image to apply the glow.');
+        }
+
+        const formData = new FormData();
+        formData.append('image', file);
+        formData.append('blur_amount', document.getElementById('blur-slider').value);
+        formData.append('brightness_threshold', document.getElementById('brightness-slider').value);
+        formData.append('strength', document.getElementById('strength-slider').value);
+
+        const response = await fetch('/image-tools/halations?response_format=json', {
+            method: 'POST',
+            body: formData
+        });
+        const result = await parseResponse(response);
+
+        const image = new Image();
+        image.src = `data:${result.content_type};base64,${result.image_base64}`;
+        image.alt = 'Halations glow result';
+
+        const download = createDownloadLinkFromBase64(
+            result.image_base64,
+            result.content_type,
+            result.filename,
+            'Download JPEG'
+        );
+
+        const nodes = [image, download];
+        if (result.message) {
+            nodes.push(createNotice(result.message));
+        }
+        nodes.push(createMetaGrid(result.metadata));
+
+        setResult('image-results', [createResultGroup('Halations Glow Result', nodes)]);
+        showToast('Halations glow applied.');
+    });
+}
+
+function setupBeforeAfterForm() {
+    attachSubmit('before-after-form', async () => {
+        const beforeInput = document.getElementById('before-image');
+        const afterInput = document.getElementById('after-image');
+        const beforeFile = beforeInput && beforeInput.files ? beforeInput.files[0] : null;
+        const afterFile = afterInput && afterInput.files ? afterInput.files[0] : null;
+        if (!beforeFile || !afterFile) {
+            throw new Error('Select both before and after images.');
+        }
+
+        const formData = new FormData();
+        formData.append('before_image', beforeFile);
+        formData.append('after_image', afterFile);
+        formData.append('duration_seconds', document.getElementById('before-after-duration').value || '6');
+        formData.append('fps', document.getElementById('before-after-fps').value || '30');
+        formData.append('cycles', document.getElementById('before-after-cycles').value || '2');
+        formData.append('line_thickness', document.getElementById('before-after-line').value || '6');
+
+        const textToggle = document.getElementById('before-after-text-toggle');
+        const overlayText = document.getElementById('before-after-text');
+        if (textToggle && textToggle.checked) {
+            formData.append('add_text', 'true');
+            if (overlayText && overlayText.value.trim()) {
+                formData.append('overlay_text', overlayText.value.trim());
+            }
+        } else {
+            formData.append('add_text', 'false');
+        }
+
+        const response = await fetch('/image-tools/before-after?response_format=json', {
+            method: 'POST',
+            body: formData
+        });
+        const result = await parseResponse(response);
+
+        const video = document.createElement('video');
+        video.controls = true;
+        video.src = `data:${result.content_type};base64,${result.video_base64}`;
+        video.setAttribute('playsinline', '');
+
+        const download = createDownloadLinkFromBase64(
+            result.video_base64,
+            result.content_type,
+            result.filename,
+            'Download MP4'
+        );
+
+        const elements = [video, download];
+        if (result.message) {
+            elements.push(createNotice(result.message));
+        }
+        elements.push(createMetaGrid(result.metadata));
+
+        setResult('image-results', [createResultGroup('Before/After Clip', elements)]);
+        showToast('Before/after animation generated.');
+    });
+}
+
+function setupPanosplitterForm() {
+    attachSubmit('panosplitter-form', async () => {
+        const imageInput = document.getElementById('panosplitter-image');
+        const file = imageInput && imageInput.files ? imageInput.files[0] : null;
+        if (!file) {
+            throw new Error('Upload a panorama image first.');
+        }
+
+        const formData = new FormData();
+        formData.append('image', file);
+        const highResCheckbox = document.getElementById('panosplitter-highres');
+        formData.append('high_res', highResCheckbox && highResCheckbox.checked ? 'true' : 'false');
+
+        const response = await fetch('/js-tools/panosplitter?response_format=json', {
+            method: 'POST',
+            body: formData
+        });
+        const result = await parseResponse(response);
+
+        const preview = new Image();
+        preview.src = `data:${result.full_view.content_type};base64,${result.full_view.base64}`;
+        preview.alt = 'Panosplitter preview';
+
+        const slicesGrid = document.createElement('div');
+        slicesGrid.className = 'slice-grid';
+        (result.slices || []).slice(0, 8).forEach((slice, index) => {
+            const img = new Image();
+            img.src = `data:${slice.content_type};base64,${slice.base64}`;
+            img.alt = `Slice ${index + 1}`;
+            slicesGrid.appendChild(img);
+        });
+
+        const download = createDownloadLinkFromBase64(
+            result.zip_file.base64,
+            result.zip_file.content_type,
+            result.zip_file.filename,
+            'Download Zip'
+        );
+
+        const elements = [preview, slicesGrid, download];
+        elements.push(createMetaGrid(result.metadata));
+        if (result.manifest) {
+            elements.push(createPre(result.manifest));
+        }
+
+        setResult('js-results', [createResultGroup('Panosplitter Output', elements)]);
+        showToast('Panorama split successfully.');
+    });
+}
+
+function setupYtDlpForm() {
+    attachSubmit('yt-dlp-form', async (form) => {
+        const urlField = document.getElementById('yt-dlp-url');
+        const formatField = document.getElementById('yt-dlp-format');
+        const binaryToggle = document.getElementById('yt-dlp-binary');
+        const filenameField = document.getElementById('yt-dlp-filename');
+
+        const urlValue = urlField.value.trim();
+        if (!urlValue) {
+            throw new Error('Provide a URL to inspect.');
+        }
+
+        const payload = {
+            url: urlValue,
+            response_format: binaryToggle.checked ? 'binary' : 'json',
+            filename: filenameField.value.trim() || null,
+            options: {
+                noplaylist: true
+            }
+        };
+
+        if (formatField.value.trim()) {
+            payload.options.format = formatField.value.trim();
+        }
+
+        const response = await fetch('/media/yt-dlp', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload)
+        });
+
+        if (binaryToggle.checked) {
+            const blob = await parseBinaryResponse(response);
+            const filename = payload.filename || parseFilename(response.headers.get('Content-Disposition')) || 'download.bin';
+            const metadataHeader = response.headers.get('X-YtDlp-Metadata');
+            const metadata = metadataHeader ? safeJsonDecode(atob(metadataHeader)) : null;
+
+            const download = createDownloadLinkFromBlob(blob, filename, 'Download Media');
+            const groups = [createResultGroup('Downloaded Media', [download])];
+            if (metadata) {
+                groups.push(createResultGroup('Metadata', [createPre(metadata)]));
+            }
+            setResult('media-results', groups);
+            showToast('Media download ready.');
+        } else {
+            const result = await parseResponse(response);
+            setResult('media-results', [createResultGroup('yt-dlp Metadata', [createPre(result.metadata)])]);
+            showToast('Metadata retrieved successfully.');
+        }
+    });
+}
+
+function attachSubmit(formId, handler) {
+    const form = document.getElementById(formId);
+    if (!form) {
+        return;
+    }
+    form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        try {
+            await withLoading(form, () => handler(form));
+        } catch (error) {
+            console.error(error);
+            showToast(error.message || 'Request failed', 'error');
+        }
+    });
+}
+
+async function withLoading(form, callback) {
+    const submit = form.querySelector('[type="submit"]');
+    const originalText = submit ? submit.textContent : null;
+    if (submit) {
+        submit.disabled = true;
+        submit.dataset.originalText = originalText || '';
+        submit.textContent = 'Processing…';
+    }
+
+    try {
+        return await callback();
+    } finally {
+        if (submit) {
+            submit.disabled = false;
+            submit.textContent = submit.dataset.originalText || originalText || 'Submit';
+        }
+    }
+}
+
+async function postJSON(url, payload) {
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+    });
+    return parseResponse(response);
+}
+
+async function parseResponse(response) {
+    const contentType = response.headers.get('content-type') || '';
+    const isJSON = contentType.includes('application/json');
+    if (isJSON) {
+        const data = await response.json();
+        if (!response.ok) {
+            throw new Error(extractMessage(data, response.status));
+        }
+        return data;
+    }
+
+    const text = await response.text();
+    if (!response.ok) {
+        throw new Error(text || `Request failed (${response.status})`);
+    }
+    return text;
+}
+
+async function parseBinaryResponse(response) {
+    if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || `Request failed (${response.status})`);
+    }
+    return response.blob();
+}
+
+function extractMessage(payload, status) {
+    if (!payload) {
+        return `Request failed (${status})`;
+    }
+    if (typeof payload === 'string') {
+        return payload;
+    }
+    if (typeof payload.detail === 'string') {
+        return payload.detail;
+    }
+    if (Array.isArray(payload.detail)) {
+        return payload.detail.map((item) => item.msg || JSON.stringify(item)).join(', ');
+    }
+    return JSON.stringify(payload, null, 2);
+}
+
+function setResult(containerId, groups) {
+    const container = document.getElementById(containerId);
+    if (!container) {
+        return;
+    }
+    container.innerHTML = '';
+    if (!groups || !groups.length) {
+        const paragraph = document.createElement('p');
+        paragraph.textContent = 'No output to display yet.';
+        container.appendChild(paragraph);
+        return;
+    }
+    groups.forEach((group) => container.appendChild(group));
+}
+
+function createResultGroup(title, nodes) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'result-group';
+    if (title) {
+        const heading = document.createElement('h4');
+        heading.textContent = title;
+        wrapper.appendChild(heading);
+    }
+    nodes.forEach((node) => {
+        wrapper.appendChild(node);
+    });
+    return wrapper;
+}
+
+function createPre(data) {
+    const pre = document.createElement('pre');
+    if (typeof data === 'string') {
+        pre.textContent = data;
+    } else {
+        pre.textContent = JSON.stringify(data, null, 2);
+    }
+    return pre;
+}
+
+function createMetaGrid(meta) {
+    const grid = document.createElement('div');
+    grid.className = 'meta-grid';
+    Object.entries(meta || {}).forEach(([key, value]) => {
+        const item = document.createElement('div');
+        item.className = 'meta-item';
+        const label = document.createElement('span');
+        label.className = 'label';
+        label.textContent = key;
+        const val = document.createElement('span');
+        val.className = 'value';
+        val.textContent = typeof value === 'object' ? JSON.stringify(value) : String(value);
+        item.append(label, val);
+        grid.appendChild(item);
+    });
+    return grid;
+}
+
+function createNotice(message) {
+    const paragraph = document.createElement('p');
+    paragraph.innerHTML = `<strong>Hint:</strong> ${escapeHtml(message)}`;
+    return paragraph;
+}
+
+function escapeHtml(value) {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function base64ToBlob(base64, contentType) {
+    const binary = window.atob(base64);
+    const len = binary.length;
+    const bytes = new Uint8Array(len);
+    for (let i = 0; i < len; i += 1) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return new Blob([bytes], { type: contentType || 'application/octet-stream' });
+}
+
+function createDownloadLinkFromBase64(base64, contentType, filename, label) {
+    const blob = base64ToBlob(base64, contentType);
+    return createDownloadLinkFromBlob(blob, filename, label);
+}
+
+function createDownloadLinkFromBlob(blob, filename, label = 'Download') {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename || 'download';
+    link.className = 'download-link';
+    link.textContent = label;
+    link.addEventListener(
+        'click',
+        () => {
+            setTimeout(() => URL.revokeObjectURL(url), 1000);
+        },
+        { once: true }
+    );
+    return link;
+}
+
+function parseFilename(disposition) {
+    if (!disposition) {
+        return null;
+    }
+    const utfMatch = /filename\*=UTF-8''([^;]+)/i.exec(disposition);
+    if (utfMatch) {
+        return decodeURIComponent(utfMatch[1]);
+    }
+    const quotedMatch = /filename="([^"\\]+)"/i.exec(disposition);
+    if (quotedMatch) {
+        return quotedMatch[1];
+    }
+    return null;
+}
+
+function safeJsonDecode(value) {
+    try {
+        return JSON.parse(value);
+    } catch (error) {
+        console.warn('Failed to decode JSON payload', error);
+        return null;
+    }
+}
+
+function showToast(message, type = 'success') {
+    const toast = document.getElementById('toast');
+    if (!toast) {
+        return;
+    }
+    toast.textContent = message;
+    toast.className = `toast ${type}`;
+    toast.hidden = false;
+    if (toastState.timer) {
+        window.clearTimeout(toastState.timer);
+    }
+    toastState.timer = window.setTimeout(() => {
+        toast.hidden = true;
+    }, 4000);
+}
+
+async function loadEndpointCatalogue() {
+    const listContainer = document.getElementById('endpoint-list');
+    const filterInput = document.getElementById('endpoint-filter');
+    if (!listContainer) {
+        return;
+    }
+
+    try {
+        const response = await fetch(OPENAPI_URL, { headers: { Accept: 'application/json' } });
+        const schema = await parseResponse(response);
+        endpointCatalogue = buildEndpointGroups(schema);
+        renderEndpointCatalogue(endpointCatalogue, listContainer, filterInput ? filterInput.value : '');
+        if (filterInput) {
+            filterInput.addEventListener('input', () => {
+                renderEndpointCatalogue(endpointCatalogue, listContainer, filterInput.value);
+            });
+        }
+    } catch (error) {
+        console.error('Failed to load OpenAPI schema', error);
+        listContainer.innerHTML = '';
+        const paragraph = document.createElement('p');
+        paragraph.textContent = 'Unable to load endpoint catalogue. Check that the API is running.';
+        listContainer.appendChild(paragraph);
+    }
+}
+
+function buildEndpointGroups(schema) {
+    const groups = {};
+    if (!schema || !schema.paths) {
+        return groups;
+    }
+    Object.entries(schema.paths).forEach(([path, methods]) => {
+        Object.entries(methods).forEach(([method, definition]) => {
+            const tags = definition.tags && definition.tags.length ? definition.tags : ['untagged'];
+            tags.forEach((tag) => {
+                const key = tag.toLowerCase();
+                if (!groups[key]) {
+                    groups[key] = { label: tag, endpoints: [] };
+                }
+                groups[key].endpoints.push({
+                    method: method.toUpperCase(),
+                    path,
+                    summary: definition.summary || definition.operationId || '',
+                    tag
+                });
+            });
+        });
+    });
+    return groups;
+}
+
+function renderEndpointCatalogue(groups, container, filterValue) {
+    container.innerHTML = '';
+    if (!groups || !Object.keys(groups).length) {
+        const paragraph = document.createElement('p');
+        paragraph.textContent = 'No endpoints found in the schema.';
+        container.appendChild(paragraph);
+        return;
+    }
+
+    const normalisedFilter = (filterValue || '').toLowerCase().trim();
+    let matched = 0;
+
+    Object.values(groups)
+        .sort((a, b) => a.label.localeCompare(b.label))
+        .forEach((group) => {
+            const filtered = group.endpoints.filter((endpoint) => {
+                if (!normalisedFilter) {
+                    return true;
+                }
+                return (
+                    group.label.toLowerCase().includes(normalisedFilter) ||
+                    endpoint.path.toLowerCase().includes(normalisedFilter) ||
+                    endpoint.summary.toLowerCase().includes(normalisedFilter)
+                );
+            });
+
+            if (!filtered.length) {
+                return;
+            }
+            matched += filtered.length;
+
+            const groupEl = document.createElement('div');
+            groupEl.className = 'endpoint-group';
+            const heading = document.createElement('h4');
+            heading.textContent = group.label;
+            groupEl.appendChild(heading);
+
+            filtered
+                .sort((a, b) => a.path.localeCompare(b.path))
+                .forEach((endpoint) => {
+                    const item = document.createElement('div');
+                    item.className = 'endpoint-item';
+                    const method = document.createElement('span');
+                    method.className = 'method';
+                    method.textContent = endpoint.method;
+                    const path = document.createElement('span');
+                    path.className = 'path';
+                    path.textContent = endpoint.path;
+                    item.append(method, path);
+                    if (endpoint.summary) {
+                        const summary = document.createElement('span');
+                        summary.className = 'muted';
+                        summary.textContent = endpoint.summary;
+                        item.appendChild(summary);
+                    }
+                    groupEl.appendChild(item);
+                });
+
+            container.appendChild(groupEl);
+        });
+
+    if (!matched) {
+        const paragraph = document.createElement('p');
+        paragraph.textContent = 'No endpoints match your filter.';
+        container.appendChild(paragraph);
+    }
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+} else {
+    init();
+}

--- a/tools-api/app/templates/studio.html
+++ b/tools-api/app/templates/studio.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tools API Studio</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
+    <link rel="stylesheet" href="/static/css/studio.css" />
+</head>
+<body>
+    <div class="app-shell">
+        <aside class="sidebar">
+            <div class="sidebar__brand">
+                <span class="sidebar__logo">🛠️</span>
+                <div>
+                    <h1>Tools API Studio</h1>
+                    <p class="sidebar__subtitle">Launch document & media workflows visually.</p>
+                </div>
+            </div>
+            <nav class="sidebar__nav">
+                <button class="nav-link active" data-section="overview">Overview</button>
+                <button class="nav-link" data-section="parser-tools">Parser</button>
+                <button class="nav-link" data-section="docx-tools">DOCX</button>
+                <button class="nav-link" data-section="image-tools">Image</button>
+                <button class="nav-link" data-section="js-tools">JS Tools</button>
+                <button class="nav-link" data-section="media-tools">Media</button>
+            </nav>
+            <div class="sidebar__footer">
+                <a class="primary-btn" href="{{ docs_url }}" target="_blank" rel="noreferrer">Open API Docs</a>
+                <p class="sidebar__hint">Swagger docs stay available at <code>{{ docs_url }}</code>.</p>
+            </div>
+        </aside>
+        <main class="content">
+            <section id="overview" class="panel">
+                <header class="panel__header">
+                    <h2>Welcome to your automation studio</h2>
+                    <p>Trigger conversions, inspect jobs, and download assets without writing cURL commands.</p>
+                </header>
+                <div class="panel__body">
+                    <div class="pill-group">
+                        <span class="pill">FastAPI {{ version }}</span>
+                        <span class="pill">Async ready</span>
+                        <span class="pill">Queue aware</span>
+                    </div>
+                    <div class="grid two-column">
+                        <div class="card">
+                            <h3>Quick Start</h3>
+                            <ol>
+                                <li>Choose a tool from the sidebar.</li>
+                                <li>Provide content or upload files.</li>
+                                <li>Launch the request and download results instantly.</li>
+                            </ol>
+                            <p class="muted">Need deeper integration? Wire these endpoints straight into n8n, Zapier, or your agent stack.</p>
+                        </div>
+                        <div class="card">
+                            <h3>Live Endpoint Catalogue</h3>
+                            <div class="endpoint-search">
+                                <label for="endpoint-filter">Search</label>
+                                <input id="endpoint-filter" type="search" placeholder="Filter by name or tag" />
+                            </div>
+                            <div id="endpoint-list" class="endpoint-list" aria-live="polite">
+                                <div class="muted">Loading endpoint catalogue…</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section id="parser-tools" class="panel">
+                <header class="panel__header">
+                    <h2>Parser</h2>
+                    <p>Convert HTML or Markdown into structured Google Docs batchUpdate operations.</p>
+                </header>
+                <div class="panel__body grid two-column">
+                    <div class="card">
+                        <form id="html-parse-form" class="tool-form">
+                            <div class="form-header">
+                                <h3>HTML → Requests</h3>
+                                <p class="muted">Paste marketing-ready HTML and receive the corresponding Google Docs operations.</p>
+                            </div>
+                            <label for="html-input">HTML</label>
+                            <textarea id="html-input" name="html" rows="8" placeholder="&lt;section&gt;...&lt;/section&gt;" required></textarea>
+                            <button type="submit" class="primary-btn">Parse HTML</button>
+                        </form>
+                    </div>
+                    <div class="card">
+                        <form id="markdown-parse-form" class="tool-form">
+                            <div class="form-header">
+                                <h3>Markdown → Requests</h3>
+                                <p class="muted">Bring GitHub-flavoured Markdown and convert it to Docs-ready mutations.</p>
+                            </div>
+                            <label for="markdown-input">Markdown</label>
+                            <textarea id="markdown-input" name="markdown" rows="8" placeholder="# Release notes" required></textarea>
+                            <button type="submit" class="primary-btn">Parse Markdown</button>
+                        </form>
+                    </div>
+                    <div class="card span-two">
+                        <form id="docs-html-form" class="tool-form">
+                            <div class="form-header">
+                                <h3>Instant Docs Request Builder</h3>
+                                <p class="muted">Generate Google Docs batchUpdate payloads from HTML without queueing a job.</p>
+                            </div>
+                            <label for="docs-html-input">HTML</label>
+                            <textarea id="docs-html-input" name="html" rows="6" placeholder="&lt;h1&gt;Launch Deck&lt;/h1&gt;" required></textarea>
+                            <button type="submit" class="primary-btn">Build Docs Requests</button>
+                        </form>
+                    </div>
+                    <div class="card span-two">
+                        <form id="docs-markdown-form" class="tool-form">
+                            <div class="form-header">
+                                <h3>Markdown Docs Builder</h3>
+                                <p class="muted">Skip the queue and transform Markdown to Docs mutations immediately.</p>
+                            </div>
+                            <label for="docs-markdown-input">Markdown</label>
+                            <textarea id="docs-markdown-input" name="markdown" rows="6" placeholder="## Agenda" required></textarea>
+                            <button type="submit" class="primary-btn">Build Docs Requests</button>
+                        </form>
+                    </div>
+                    <div id="parser-results" class="result-panel span-two" aria-live="polite"></div>
+                </div>
+            </section>
+
+            <section id="docx-tools" class="panel">
+                <header class="panel__header">
+                    <h2>DOCX Toolkit</h2>
+                    <p>Upload Word documents and extract plain text instantly.</p>
+                </header>
+                <div class="panel__body grid two-column">
+                    <div class="card">
+                        <form id="docx-parse-form" class="tool-form">
+                            <div class="form-header">
+                                <h3>Parse DOCX</h3>
+                                <p class="muted">Drop a .docx file to stream back the cleaned text.</p>
+                            </div>
+                            <label for="docx-file">DOCX file</label>
+                            <input id="docx-file" type="file" accept=".docx" required />
+                            <button type="submit" class="primary-btn">Extract Text</button>
+                        </form>
+                    </div>
+                    <div id="docx-results" class="result-panel" aria-live="polite"></div>
+                </div>
+            </section>
+
+            <section id="image-tools" class="panel">
+                <header class="panel__header">
+                    <h2>Image Studio</h2>
+                    <p>Apply glow effects or create before/after promos without leaving the browser.</p>
+                </header>
+                <div class="panel__body grid two-column">
+                    <div class="card">
+                        <form id="halations-form" class="tool-form">
+                            <div class="form-header">
+                                <h3>Halations Glow</h3>
+                                <p class="muted">Upload an image and tune the glow with live sliders.</p>
+                            </div>
+                            <label for="halations-image">Image</label>
+                            <input id="halations-image" type="file" accept="image/*" required />
+                            <div class="slider-group">
+                                <label>Blur amount <span id="blur-value">10</span></label>
+                                <input id="blur-slider" type="range" min="0" max="50" step="1" value="10" />
+                            </div>
+                            <div class="slider-group">
+                                <label>Brightness threshold <span id="brightness-value">200</span></label>
+                                <input id="brightness-slider" type="range" min="0" max="255" step="5" value="200" />
+                            </div>
+                            <div class="slider-group">
+                                <label>Strength <span id="strength-value">50</span></label>
+                                <input id="strength-slider" type="range" min="0" max="150" step="1" value="50" />
+                            </div>
+                            <button type="submit" class="primary-btn">Apply Glow</button>
+                        </form>
+                    </div>
+                    <div class="card">
+                        <form id="before-after-form" class="tool-form">
+                            <div class="form-header">
+                                <h3>Before/After Swipe</h3>
+                                <p class="muted">Blend two visuals into a motion clip with optional captions.</p>
+                            </div>
+                            <label for="before-image">Before image</label>
+                            <input id="before-image" type="file" accept="image/*" required />
+                            <label for="after-image">After image</label>
+                            <input id="after-image" type="file" accept="image/*" required />
+                            <div class="form-row">
+                                <label for="before-after-duration">Duration (seconds)</label>
+                                <input id="before-after-duration" type="number" min="1" max="20" step="0.5" value="6" />
+                                <label for="before-after-fps">FPS</label>
+                                <input id="before-after-fps" type="number" min="1" max="60" step="1" value="30" />
+                            </div>
+                            <div class="form-row">
+                                <label for="before-after-cycles">Cycles</label>
+                                <input id="before-after-cycles" type="number" min="1" max="10" step="1" value="2" />
+                                <label for="before-after-line">Line thickness</label>
+                                <input id="before-after-line" type="number" min="1" max="20" step="1" value="6" />
+                            </div>
+                            <label class="checkbox">
+                                <input id="before-after-text-toggle" type="checkbox" />
+                                <span>Add overlay text</span>
+                            </label>
+                            <textarea id="before-after-text" rows="2" placeholder="Save 35% this quarter" style="display: none;"></textarea>
+                            <button type="submit" class="primary-btn">Generate Clip</button>
+                        </form>
+                    </div>
+                    <div id="image-results" class="result-panel span-two" aria-live="polite"></div>
+                </div>
+            </section>
+
+            <section id="js-tools" class="panel">
+                <header class="panel__header">
+                    <h2>JavaScript Tools</h2>
+                    <p>Bridge Node-powered utilities like the panorama splitter straight from the browser.</p>
+                </header>
+                <div class="panel__body grid two-column">
+                    <div class="card span-two">
+                        <form id="panosplitter-form" class="tool-form">
+                            <div class="form-header">
+                                <h3>Panosplitter</h3>
+                                <p class="muted">Upload a panorama and get Instagram-ready slices plus a downloadable zip.</p>
+                            </div>
+                            <label for="panosplitter-image">Panorama image</label>
+                            <input id="panosplitter-image" type="file" accept="image/*" required />
+                            <label class="checkbox">
+                                <input id="panosplitter-highres" type="checkbox" />
+                                <span>Enable high resolution mode</span>
+                            </label>
+                            <button type="submit" class="primary-btn">Split Panorama</button>
+                        </form>
+                    </div>
+                    <div id="js-results" class="result-panel span-two" aria-live="polite"></div>
+                </div>
+            </section>
+
+            <section id="media-tools" class="panel">
+                <header class="panel__header">
+                    <h2>Media Toolkit</h2>
+                    <p>Inspect or download media via yt-dlp without touching the command line.</p>
+                </header>
+                <div class="panel__body grid two-column">
+                    <div class="card span-two">
+                        <form id="yt-dlp-form" class="tool-form">
+                            <div class="form-header">
+                                <h3>yt-dlp Inspector</h3>
+                                <p class="muted">Fetch metadata or trigger a download with safe defaults.</p>
+                            </div>
+                            <label for="yt-dlp-url">URL</label>
+                            <input id="yt-dlp-url" type="url" required placeholder="https://www.youtube.com/watch?v=..." />
+                            <label for="yt-dlp-format">Format selector (optional)</label>
+                            <input id="yt-dlp-format" type="text" placeholder="bestvideo+bestaudio/best" />
+                            <label class="checkbox">
+                                <input id="yt-dlp-binary" type="checkbox" />
+                                <span>Return binary download</span>
+                            </label>
+                            <label for="yt-dlp-filename">Filename override (binary only)</label>
+                            <input id="yt-dlp-filename" type="text" placeholder="custom.mp4" />
+                            <button type="submit" class="primary-btn">Run yt-dlp</button>
+                        </form>
+                    </div>
+                    <div id="media-results" class="result-panel span-two" aria-live="polite"></div>
+                </div>
+            </section>
+        </main>
+    </div>
+    <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
+    <script>
+        window.__STUDIO_CONFIG__ = {
+            openapiUrl: "{{ openapi_url }}"
+        };
+    </script>
+    <script src="/static/js/studio.js" type="module"></script>
+</body>
+</html>

--- a/tools-api/requirements.txt
+++ b/tools-api/requirements.txt
@@ -1,5 +1,6 @@
 beautifulsoup4
 fastapi
+jinja2
 httpx
 markdown
 pydantic

--- a/tools-api/run_all.py
+++ b/tools-api/run_all.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from app.runtime.cli import main
+from app.runtime.preflight import prepare_environment
 
 
 if __name__ == "__main__":
+    prepare_environment()
     main()


### PR DESCRIPTION
## Summary
- serve a new Tools API Studio dashboard at the root FastAPI route with structured sections for parser, DOCX, image, JavaScript, and media tooling
- add dedicated CSS/JS assets to power uploads, sliders, downloads, and live OpenAPI endpoint listings
- run dependency preflight checks before boot via run_all.py and include the required Jinja2 package for template rendering

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'imageio')*

------
https://chatgpt.com/codex/tasks/task_e_68e102fad81483289efcae79c14a73ab