### PR TITLE
Add Cobalt Studio card and expand yt-dlp subtitle options

### DIFF
--- a/tools-api/README.md
+++ b/tools-api/README.md
@@ -108,6 +108,8 @@ export COBALT_API_TIMEOUT="90"
 
 Once configured you can `POST /js-tools/cobalt` with any options supported by Cobalt's schema (for example `audioFormat`, `videoQuality`, or service-specific flags). Default responses return the raw JSON from Cobalt. Include `{"response_format": "binary"}` to download the media bytes directly via Tools API.
 
+> Tip: Tools API Studio ships with a dedicated Cobalt card so you can paste a URL, toggle binary responses, override filenames, and send raw JSON payloads without crafting curl commands.
+
 #### yt-dlp media helper
 Tools API now ships with a thin wrapper around [yt-dlp](https://github.com/yt-dlp/yt-dlp) for quick metadata lookups or direct downloads:
 
@@ -123,6 +125,7 @@ curl -X POST http://localhost:8000/media/yt-dlp \
 - Default responses return the full yt-dlp metadata, perfect for agent reasoning or UI previews.
 - Set `"response_format": "binary"` to receive the media stream directly. The response includes `Content-Disposition` and `X-YtDlp-Metadata` headers to keep n8n or Zapier automations informed about the download.
 - Pass optional headers (cookies, auth) or proxy settings via the `options` object to handle restricted content.
+- Target specific playlist entries with `playlist_items` and enable subtitle workflows using `writesubtitles`, `writeautomaticsub`, and `subtitleslangs`. The Studio surfaces subtitle metadata alongside JSON and binary responses so you can link caption downloads in one click.
 
 ### Docker
 ```bash

--- a/tools-api/app/routers/media.py
+++ b/tools-api/app/routers/media.py
@@ -32,6 +32,18 @@ class YtDlpOptions(BaseModel):
         description="Optional HTTP headers to send with the request (e.g. cookies or authorization).",
     )
     proxy: str | None = Field(default=None, description="Optional proxy URL passed directly to yt-dlp.")
+    writesubtitles: bool = Field(
+        default=False,
+        description="Download subtitles alongside the main media when available.",
+    )
+    writeautomaticsub: bool = Field(
+        default=False,
+        description="Download automatically generated subtitles if authored subtitles are missing.",
+    )
+    subtitleslangs: list[str] | None = Field(
+        default=None,
+        description="List of subtitle language codes to prioritise (yt-dlp subtitleslangs option).",
+    )
 
     def to_yt_dlp_kwargs(self) -> Dict[str, Any]:
         payload: Dict[str, Any] = {}
@@ -44,6 +56,12 @@ class YtDlpOptions(BaseModel):
             payload["http_headers"] = self.http_headers
         if self.proxy:
             payload["proxy"] = self.proxy
+        if self.writesubtitles:
+            payload["writesubtitles"] = True
+        if self.writeautomaticsub:
+            payload["writeautomaticsub"] = True
+        if self.subtitleslangs:
+            payload["subtitleslangs"] = self.subtitleslangs
         return payload
 
 

--- a/tools-api/app/static/css/studio.css
+++ b/tools-api/app/static/css/studio.css
@@ -382,6 +382,59 @@ textarea {
     background: rgba(79, 139, 255, 0.3);
 }
 
+.subtitle-list {
+    display: grid;
+    gap: 10px;
+}
+
+.subtitle-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+}
+
+.subtitle-lang {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(79, 139, 255, 0.2);
+    color: var(--text);
+    font-weight: 600;
+    font-size: 0.8rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.subtitle-details {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+.subtitle-details span {
+    color: var(--text);
+    font-weight: 500;
+}
+
+.subtitle-link {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.subtitle-link:hover {
+    text-decoration: underline;
+}
+
 .meta-grid {
     display: grid;
     gap: 10px;

--- a/tools-api/app/templates/studio.html
+++ b/tools-api/app/templates/studio.html
@@ -225,6 +225,25 @@
                             <button type="submit" class="primary-btn">Split Panorama</button>
                         </form>
                     </div>
+                    <div class="card span-two">
+                        <form id="cobalt-form" class="tool-form">
+                            <div class="form-header">
+                                <h3>Cobalt Downloader</h3>
+                                <p class="muted">Proxy downloads through your configured Cobalt instance without leaving the browser.</p>
+                            </div>
+                            <label for="cobalt-url">URL</label>
+                            <input id="cobalt-url" type="url" required placeholder="https://www.youtube.com/watch?v=..." />
+                            <label class="checkbox">
+                                <input id="cobalt-binary" type="checkbox" />
+                                <span>Return binary download</span>
+                            </label>
+                            <label for="cobalt-filename">Filename override (binary only)</label>
+                            <input id="cobalt-filename" type="text" placeholder="custom.mp4" />
+                            <label for="cobalt-payload">Raw JSON payload (optional)</label>
+                            <textarea id="cobalt-payload" rows="5" placeholder='{"audioFormat": "mp3", "videoQuality": "1080"}'></textarea>
+                            <button type="submit" class="primary-btn">Send to Cobalt</button>
+                        </form>
+                    </div>
                     <div id="js-results" class="result-panel span-two" aria-live="polite"></div>
                 </div>
             </section>
@@ -245,12 +264,30 @@
                             <input id="yt-dlp-url" type="url" required placeholder="https://www.youtube.com/watch?v=..." />
                             <label for="yt-dlp-format">Format selector (optional)</label>
                             <input id="yt-dlp-format" type="text" placeholder="bestvideo+bestaudio/best" />
+                            <label for="yt-dlp-playlist-items">Playlist items (e.g. 1-3,5)</label>
+                            <input id="yt-dlp-playlist-items" type="text" placeholder="1-3,5" />
                             <label class="checkbox">
                                 <input id="yt-dlp-binary" type="checkbox" />
                                 <span>Return binary download</span>
                             </label>
                             <label for="yt-dlp-filename">Filename override (binary only)</label>
                             <input id="yt-dlp-filename" type="text" placeholder="custom.mp4" />
+                            <label for="yt-dlp-headers">HTTP headers (JSON object)</label>
+                            <textarea id="yt-dlp-headers" rows="3" placeholder='{"Cookie": "session=..."}'></textarea>
+                            <label for="yt-dlp-proxy">Proxy URL</label>
+                            <input id="yt-dlp-proxy" type="text" placeholder="socks5://localhost:9050" />
+                            <div class="form-row">
+                                <label class="checkbox">
+                                    <input id="yt-dlp-write-subtitles" type="checkbox" />
+                                    <span>Write subtitles</span>
+                                </label>
+                                <label class="checkbox">
+                                    <input id="yt-dlp-write-auto-sub" type="checkbox" />
+                                    <span>Write automatic subs</span>
+                                </label>
+                            </div>
+                            <label for="yt-dlp-subtitle-langs">Subtitle languages (comma separated)</label>
+                            <input id="yt-dlp-subtitle-langs" type="text" placeholder="en,es" />
                             <button type="submit" class="primary-btn">Run yt-dlp</button>
                         </form>
                     </div>


### PR DESCRIPTION
## Summary
- add a Cobalt downloader card to the Studio that supports binary responses, filename overrides, and raw JSON payload editing
- expand the yt-dlp Media Toolkit form and front-end rendering to cover playlist items, headers, proxy, and subtitle metadata
- extend the yt-dlp API options, docs, and tests to cover the new subtitle-related fields
- handle missing optional jinja2 dependency gracefully so Studio still responds and automated tests can run

## Testing
- pytest tools-api/tests/test_media.py

------
https://chatgpt.com/codex/tasks/task_e_68e1094b7f548328a46677da2aeb6d25