### PR TITLE
Enhance Cobalt studio interface with presets and option builder

### DIFF
--- a/tools-api/README.md
+++ b/tools-api/README.md
@@ -108,7 +108,7 @@ export COBALT_API_TIMEOUT="90"
 
 Once configured you can `POST /js-tools/cobalt` with any options supported by Cobalt's schema (for example `audioFormat`, `videoQuality`, or service-specific flags). Default responses return the raw JSON from Cobalt. Include `{"response_format": "binary"}` to download the media bytes directly via Tools API.
 
-> Tip: Tools API Studio ships with a dedicated Cobalt card so you can paste a URL, toggle binary responses, override filenames, and send raw JSON payloads without crafting curl commands.
+> Tip: Tools API Studio ships with a dedicated Cobalt card so you can paste a URL, mix and match presets, tweak audio/video formats, toggle service-specific flags, add custom key/value pairs, or fall back to raw JSON—no curl gymnastics required.
 
 #### yt-dlp media helper
 Tools API now ships with a thin wrapper around [yt-dlp](https://github.com/yt-dlp/yt-dlp) for quick metadata lookups or direct downloads:

--- a/tools-api/app/static/css/studio.css
+++ b/tools-api/app/static/css/studio.css
@@ -244,7 +244,8 @@ input[type="url"],
 input[type="number"],
 textarea,
 input[type="search"],
-input[type="file"] {
+input[type="file"],
+select {
     width: 100%;
     padding: 10px 12px;
     background: rgba(9, 15, 28, 0.75);
@@ -261,7 +262,8 @@ input[type="url"]:focus,
 input[type="number"]:focus,
 textarea:focus,
 input[type="search"]:focus,
-input[type="file"]:focus {
+input[type="file"]:focus,
+select:focus {
     outline: none;
     border-color: rgba(79, 139, 255, 0.6);
     box-shadow: 0 0 0 4px rgba(79, 139, 255, 0.15);
@@ -284,6 +286,60 @@ textarea {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
     gap: 12px;
+}
+
+#cobalt-preset-description {
+    margin: -4px 0 12px;
+}
+
+.checkbox-group {
+    display: grid;
+    gap: 12px;
+    align-content: flex-start;
+}
+
+.cobalt-options {
+    display: grid;
+    gap: 12px;
+}
+
+.cobalt-option-row {
+    grid-template-columns: minmax(160px, 1fr) minmax(140px, 0.7fr) minmax(160px, 1fr) auto;
+    align-items: center;
+}
+
+#cobalt-add-option {
+    justify-self: start;
+}
+
+.text-btn {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    color: var(--accent);
+    padding: 8px 12px;
+    border-radius: var(--radius-sm);
+    font-size: 0.85rem;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.text-btn:hover {
+    background: rgba(79, 139, 255, 0.12);
+    border-color: rgba(79, 139, 255, 0.35);
+}
+
+.cobalt-option-row .text-btn {
+    color: var(--danger);
+    border-color: rgba(248, 113, 113, 0.35);
+}
+
+.cobalt-option-row .text-btn:hover {
+    background: rgba(248, 113, 113, 0.18);
+    border-color: rgba(248, 113, 113, 0.5);
+    color: #fff;
 }
 
 .checkbox {
@@ -574,5 +630,13 @@ textarea {
 
     .card.span-two {
         grid-column: span 1;
+    }
+
+    .cobalt-option-row {
+        grid-template-columns: 1fr;
+    }
+
+    .cobalt-option-row .text-btn {
+        justify-self: start;
     }
 }

--- a/tools-api/app/static/js/studio.js
+++ b/tools-api/app/static/js/studio.js
@@ -3,6 +3,33 @@ const OPENAPI_URL = config.openapiUrl || '/openapi.json';
 const toastState = { timer: null };
 let endpointCatalogue = null;
 
+const COBALT_FIELD_IDS = {
+    service: 'cobalt-service',
+    downloadMode: 'cobalt-download-mode',
+    filenameStyle: 'cobalt-filename-style',
+    audioFormat: 'cobalt-audio-format',
+    audioBitrate: 'cobalt-audio-bitrate',
+    videoQuality: 'cobalt-video-quality',
+    youtubeVideoCodec: 'cobalt-youtube-video-codec',
+    youtubeVideoContainer: 'cobalt-youtube-video-container',
+    localProcessing: 'cobalt-local-processing',
+    subtitleLang: 'cobalt-subtitle-lang',
+    youtubeDubLang: 'cobalt-youtube-dub-lang'
+};
+
+const COBALT_BOOLEAN_FIELDS = {
+    alwaysProxy: 'cobalt-always-proxy',
+    disableMetadata: 'cobalt-disable-metadata',
+    allowH265: 'cobalt-allow-h265',
+    tiktokFullAudio: 'cobalt-tiktok-full-audio',
+    youtubeBetterAudio: 'cobalt-youtube-better-audio',
+    youtubeHLS: 'cobalt-youtube-hls'
+};
+
+const COBALT_BOOLEAN_SELECT_FIELDS = {
+    convertGif: 'cobalt-convert-gif'
+};
+
 function init() {
     setupNavigation();
     setupSectionObserver();
@@ -123,6 +150,7 @@ function setupForms() {
     setupHalationsForm();
     setupBeforeAfterForm();
     setupPanosplitterForm();
+    setupCobaltControls();
     setupCobaltForm();
     setupYtDlpForm();
 }
@@ -355,6 +383,294 @@ function setupPanosplitterForm() {
     });
 }
 
+function setupCobaltControls() {
+    const presetSelect = document.getElementById('cobalt-preset');
+    if (presetSelect) {
+        presetSelect.addEventListener('change', () => {
+            applyCobaltPreset(presetSelect);
+            updateCobaltPresetDescription(presetSelect);
+        });
+        updateCobaltPresetDescription(presetSelect);
+    }
+
+    const customOptionsContainer = document.getElementById('cobalt-custom-options');
+    if (customOptionsContainer) {
+        customOptionsContainer.addEventListener('click', (event) => {
+            const target = event.target;
+            if (target instanceof HTMLElement && target.hasAttribute('data-option-remove')) {
+                const row = target.closest('.cobalt-option-row');
+                if (row) {
+                    row.remove();
+                }
+            }
+        });
+
+        customOptionsContainer.addEventListener('change', (event) => {
+            const target = event.target;
+            if (target instanceof HTMLSelectElement && target.hasAttribute('data-option-type')) {
+                setCobaltOptionPlaceholder(target);
+            }
+        });
+    }
+
+    if (customOptionsContainer && !customOptionsContainer.querySelector('.cobalt-option-row')) {
+        addCobaltOptionRow();
+    }
+
+    const addOptionButton = document.getElementById('cobalt-add-option');
+    if (addOptionButton) {
+        addOptionButton.addEventListener('click', () => addCobaltOptionRow());
+    }
+}
+
+function applyCobaltPreset(select) {
+    if (!(select instanceof HTMLSelectElement)) {
+        return;
+    }
+
+    const option = select.selectedOptions[0];
+    if (!option) {
+        return;
+    }
+
+    const shouldReset = option.dataset.reset !== 'false';
+    let presetValues = {};
+
+    if (shouldReset) {
+        resetCobaltPresetFields();
+    }
+
+    if (option.dataset.options) {
+        try {
+            presetValues = JSON.parse(option.dataset.options);
+        } catch (error) {
+            console.warn('Invalid preset configuration for Cobalt option', error);
+        }
+    }
+
+    const binaryToggle = document.getElementById('cobalt-binary');
+    const filenameField = document.getElementById('cobalt-filename');
+
+    Object.entries(presetValues).forEach(([key, value]) => {
+        if (key === 'response_format' && binaryToggle instanceof HTMLInputElement) {
+            binaryToggle.checked = String(value).toLowerCase() === 'binary';
+            return;
+        }
+
+        if (key === 'download_filename' && filenameField instanceof HTMLInputElement) {
+            filenameField.value = String(value);
+            return;
+        }
+
+        if (Object.prototype.hasOwnProperty.call(COBALT_FIELD_IDS, key)) {
+            const fieldId = COBALT_FIELD_IDS[key];
+            const field = document.getElementById(fieldId);
+            if (field instanceof HTMLInputElement || field instanceof HTMLSelectElement) {
+                field.value = String(value);
+            }
+            return;
+        }
+
+        if (Object.prototype.hasOwnProperty.call(COBALT_BOOLEAN_FIELDS, key)) {
+            const fieldId = COBALT_BOOLEAN_FIELDS[key];
+            const field = document.getElementById(fieldId);
+            if (field instanceof HTMLInputElement) {
+                field.checked = Boolean(value);
+            }
+            return;
+        }
+
+        if (Object.prototype.hasOwnProperty.call(COBALT_BOOLEAN_SELECT_FIELDS, key)) {
+            const fieldId = COBALT_BOOLEAN_SELECT_FIELDS[key];
+            const field = document.getElementById(fieldId);
+            if (field instanceof HTMLSelectElement) {
+                if (value === true || value === 'true') {
+                    field.value = 'true';
+                } else if (value === false || value === 'false') {
+                    field.value = 'false';
+                } else {
+                    field.value = '';
+                }
+            }
+        }
+    });
+}
+
+function resetCobaltPresetFields() {
+    Object.values(COBALT_FIELD_IDS).forEach((fieldId) => {
+        const field = document.getElementById(fieldId);
+        if (field instanceof HTMLInputElement || field instanceof HTMLSelectElement) {
+            field.value = '';
+        }
+    });
+
+    Object.values(COBALT_BOOLEAN_FIELDS).forEach((fieldId) => {
+        const field = document.getElementById(fieldId);
+        if (field instanceof HTMLInputElement) {
+            field.checked = false;
+        }
+    });
+
+    Object.values(COBALT_BOOLEAN_SELECT_FIELDS).forEach((fieldId) => {
+        const field = document.getElementById(fieldId);
+        if (field instanceof HTMLSelectElement) {
+            field.value = '';
+        }
+    });
+
+    const binaryToggle = document.getElementById('cobalt-binary');
+    if (binaryToggle instanceof HTMLInputElement) {
+        binaryToggle.checked = false;
+    }
+
+    const filenameField = document.getElementById('cobalt-filename');
+    if (filenameField instanceof HTMLInputElement) {
+        filenameField.value = '';
+    }
+}
+
+function updateCobaltPresetDescription(select) {
+    const description = document.getElementById('cobalt-preset-description');
+    if (!(select instanceof HTMLSelectElement) || !description) {
+        return;
+    }
+
+    const option = select.selectedOptions[0];
+    if (option && option.dataset.description) {
+        description.textContent = option.dataset.description;
+        description.hidden = false;
+    } else {
+        description.textContent = '';
+        description.hidden = true;
+    }
+}
+
+function addCobaltOptionRow(key = '', value = '', type = 'string') {
+    const container = document.getElementById('cobalt-custom-options');
+    const template = document.getElementById('cobalt-option-template');
+    if (!container || !(template instanceof HTMLTemplateElement)) {
+        return;
+    }
+
+    const clone = template.content.firstElementChild.cloneNode(true);
+    const keyInput = clone.querySelector('[data-option-key]');
+    const valueInput = clone.querySelector('[data-option-value]');
+    const typeSelect = clone.querySelector('[data-option-type]');
+
+    if (keyInput instanceof HTMLInputElement) {
+        keyInput.value = key;
+    }
+    if (valueInput instanceof HTMLInputElement) {
+        valueInput.value = value;
+    }
+    if (typeSelect instanceof HTMLSelectElement) {
+        if (Array.from(typeSelect.options).some((optionEl) => optionEl.value === type)) {
+            typeSelect.value = type;
+        }
+        setCobaltOptionPlaceholder(typeSelect);
+    }
+
+    container.appendChild(clone);
+}
+
+function setCobaltOptionPlaceholder(typeSelect) {
+    const row = typeSelect.closest('.cobalt-option-row');
+    if (!row) {
+        return;
+    }
+    const valueInput = row.querySelector('[data-option-value]');
+    if (!(valueInput instanceof HTMLInputElement)) {
+        return;
+    }
+
+    const placeholders = {
+        string: 'value',
+        number: '123',
+        boolean: 'true / false',
+        json: '{"key":"value"}'
+    };
+
+    valueInput.placeholder = placeholders[typeSelect.value] || 'value';
+}
+
+function collectCobaltCustomOptions() {
+    const container = document.getElementById('cobalt-custom-options');
+    if (!container) {
+        return {};
+    }
+
+    const options = {};
+    const rows = container.querySelectorAll('.cobalt-option-row');
+
+    rows.forEach((row) => {
+        const keyInput = row.querySelector('[data-option-key]');
+        const valueInput = row.querySelector('[data-option-value]');
+        const typeSelect = row.querySelector('[data-option-type]');
+
+        const key = keyInput instanceof HTMLInputElement ? keyInput.value.trim() : '';
+        const rawValue = valueInput instanceof HTMLInputElement ? valueInput.value.trim() : '';
+        const type = typeSelect instanceof HTMLSelectElement ? typeSelect.value : 'string';
+
+        if (!key && !rawValue) {
+            return;
+        }
+
+        if (!key) {
+            throw new Error('Provide a key for each custom option.');
+        }
+
+        if (!rawValue) {
+            throw new Error(`Provide a value for the custom option "${key}".`);
+        }
+
+        try {
+            options[key] = transformCobaltCustomOptionValue(type, rawValue);
+        } catch (error) {
+            if (error instanceof SyntaxError && type === 'json') {
+                throw new Error(`Custom option "${key}" must be valid JSON.`);
+            }
+            if (error instanceof TypeError) {
+                if (error.message === 'number') {
+                    throw new Error(`Custom option "${key}" must be a valid number.`);
+                }
+                if (error.message === 'boolean') {
+                    throw new Error(`Custom option "${key}" must be 'true' or 'false'.`);
+                }
+            }
+            throw new Error(`Unable to parse the value for custom option "${key}".`);
+        }
+    });
+
+    return options;
+}
+
+function transformCobaltCustomOptionValue(type, rawValue) {
+    if (type === 'number') {
+        const parsed = Number(rawValue);
+        if (Number.isNaN(parsed)) {
+            throw new TypeError('number');
+        }
+        return parsed;
+    }
+
+    if (type === 'boolean') {
+        const normalized = rawValue.toLowerCase();
+        if (['true', '1', 'yes', 'on'].includes(normalized)) {
+            return true;
+        }
+        if (['false', '0', 'no', 'off'].includes(normalized)) {
+            return false;
+        }
+        throw new TypeError('boolean');
+    }
+
+    if (type === 'json') {
+        return JSON.parse(rawValue);
+    }
+
+    return rawValue;
+}
+
 function setupCobaltForm() {
     attachSubmit('cobalt-form', async () => {
         const urlField = document.getElementById('cobalt-url');
@@ -380,8 +696,9 @@ function setupCobaltForm() {
             }
         }
 
+        const customOptions = collectCobaltCustomOptions();
+
         const payload = {
-            ...(extraPayload || {}),
             url: urlValue,
             response_format: binaryToggle.checked ? 'binary' : 'json'
         };
@@ -389,6 +706,42 @@ function setupCobaltForm() {
         const filenameOverride = filenameField.value.trim();
         if (filenameOverride) {
             payload.download_filename = filenameOverride;
+        }
+
+        Object.entries(COBALT_FIELD_IDS).forEach(([key, fieldId]) => {
+            const field = document.getElementById(fieldId);
+            if (field instanceof HTMLInputElement || field instanceof HTMLSelectElement) {
+                const value = field.value.trim();
+                if (value) {
+                    payload[key] = value;
+                }
+            }
+        });
+
+        Object.entries(COBALT_BOOLEAN_FIELDS).forEach(([key, fieldId]) => {
+            const field = document.getElementById(fieldId);
+            if (field instanceof HTMLInputElement && field.checked) {
+                payload[key] = true;
+            }
+        });
+
+        Object.entries(COBALT_BOOLEAN_SELECT_FIELDS).forEach(([key, fieldId]) => {
+            const field = document.getElementById(fieldId);
+            if (field instanceof HTMLSelectElement) {
+                if (field.value === 'true') {
+                    payload[key] = true;
+                } else if (field.value === 'false') {
+                    payload[key] = false;
+                }
+            }
+        });
+
+        if (customOptions && Object.keys(customOptions).length) {
+            Object.assign(payload, customOptions);
+        }
+
+        if (extraPayload && Object.keys(extraPayload).length) {
+            Object.assign(payload, extraPayload);
         }
 
         const response = await fetch('/js-tools/cobalt', {

--- a/tools-api/app/templates/studio.html
+++ b/tools-api/app/templates/studio.html
@@ -233,14 +233,200 @@
                             </div>
                             <label for="cobalt-url">URL</label>
                             <input id="cobalt-url" type="url" required placeholder="https://www.youtube.com/watch?v=..." />
-                            <label class="checkbox">
-                                <input id="cobalt-binary" type="checkbox" />
-                                <span>Return binary download</span>
-                            </label>
+                            <div class="form-row">
+                                <div>
+                                    <label for="cobalt-service">Service override (optional)</label>
+                                    <select id="cobalt-service">
+                                        <option value="">Auto detect</option>
+                                        <option value="youtube">YouTube</option>
+                                        <option value="tiktok">TikTok</option>
+                                        <option value="instagram">Instagram</option>
+                                        <option value="twitter">Twitter / X</option>
+                                        <option value="soundcloud">SoundCloud</option>
+                                        <option value="facebook">Facebook</option>
+                                    </select>
+                                </div>
+                                <div>
+                                    <label for="cobalt-preset">Quick preset</label>
+                                    <select id="cobalt-preset">
+                                        <option value="custom" data-reset="false" data-options="{}" data-description="Start with a blank payload and build your own combination of options.">Custom (manual)</option>
+                                        <option value="audio-mp3" data-options='{"downloadMode":"audio","audioFormat":"mp3","audioBitrate":"320","response_format":"binary"}' data-description="Audio-only MP3 download at 320 kbps. Binary responses are enabled so you can save directly.">High bitrate MP3</option>
+                                        <option value="audio-ogg" data-options='{"downloadMode":"audio","audioFormat":"ogg","audioBitrate":"96","response_format":"binary"}' data-description="Lightweight OGG/Vorbis audio tuned for spoken-word content and lower bandwidth." data-reset="true">Compact podcast OGG</option>
+                                        <option value="video-1080" data-options='{"videoQuality":"1080","youtubeVideoCodec":"h264","youtubeVideoContainer":"mp4","response_format":"binary"}' data-description="1080p MP4 download using the H.264 codec for broad compatibility." data-reset="true">1080p MP4 (H.264)</option>
+                                        <option value="video-4k" data-options='{"videoQuality":"2160","youtubeVideoCodec":"av1","youtubeVideoContainer":"webm","response_format":"binary","alwaysProxy":true}' data-description="Force 4K WebM output via AV1 with proxying enabled for the largest files." data-reset="true">4K WebM (AV1)</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <p id="cobalt-preset-description" class="muted" hidden></p>
+                            <div class="form-row">
+                                <label class="checkbox">
+                                    <input id="cobalt-binary" type="checkbox" />
+                                    <span>Return binary download</span>
+                                </label>
+                                <label class="checkbox">
+                                    <input id="cobalt-always-proxy" type="checkbox" />
+                                    <span>Always proxy downloads</span>
+                                </label>
+                                <label class="checkbox">
+                                    <input id="cobalt-disable-metadata" type="checkbox" />
+                                    <span>Strip metadata from files</span>
+                                </label>
+                            </div>
                             <label for="cobalt-filename">Filename override (binary only)</label>
                             <input id="cobalt-filename" type="text" placeholder="custom.mp4" />
-                            <label for="cobalt-payload">Raw JSON payload (optional)</label>
-                            <textarea id="cobalt-payload" rows="5" placeholder='{"audioFormat": "mp3", "videoQuality": "1080"}'></textarea>
+                            <div class="form-row">
+                                <div>
+                                    <label for="cobalt-download-mode">Download mode</label>
+                                    <select id="cobalt-download-mode">
+                                        <option value="">Use instance default</option>
+                                        <option value="auto">Auto (audio + video)</option>
+                                        <option value="audio">Audio only</option>
+                                        <option value="mute">Mute video</option>
+                                    </select>
+                                </div>
+                                <div>
+                                    <label for="cobalt-filename-style">Filename style</label>
+                                    <select id="cobalt-filename-style">
+                                        <option value="">Use instance default</option>
+                                        <option value="classic">Classic</option>
+                                        <option value="pretty">Pretty</option>
+                                        <option value="basic">Basic</option>
+                                        <option value="nerdy">Nerdy</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <div>
+                                    <label for="cobalt-audio-format">Audio format</label>
+                                    <select id="cobalt-audio-format">
+                                        <option value="">Use instance default</option>
+                                        <option value="best">Best available</option>
+                                        <option value="mp3">MP3</option>
+                                        <option value="ogg">OGG / Vorbis</option>
+                                        <option value="wav">WAV</option>
+                                        <option value="opus">Opus</option>
+                                    </select>
+                                </div>
+                                <div>
+                                    <label for="cobalt-audio-bitrate">Audio bitrate (kbps)</label>
+                                    <select id="cobalt-audio-bitrate">
+                                        <option value="">Use instance default</option>
+                                        <option value="320">320</option>
+                                        <option value="256">256</option>
+                                        <option value="192">192</option>
+                                        <option value="128">128</option>
+                                        <option value="96">96</option>
+                                        <option value="64">64</option>
+                                        <option value="8">8</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <div>
+                                    <label for="cobalt-video-quality">Video quality</label>
+                                    <select id="cobalt-video-quality">
+                                        <option value="">Use instance default</option>
+                                        <option value="max">Maximum available</option>
+                                        <option value="4320">4320p</option>
+                                        <option value="2160">2160p (4K)</option>
+                                        <option value="1440">1440p</option>
+                                        <option value="1080">1080p</option>
+                                        <option value="720">720p</option>
+                                        <option value="480">480p</option>
+                                        <option value="360">360p</option>
+                                        <option value="240">240p</option>
+                                        <option value="144">144p</option>
+                                    </select>
+                                </div>
+                                <div>
+                                    <label for="cobalt-youtube-video-codec">YouTube video codec</label>
+                                    <select id="cobalt-youtube-video-codec">
+                                        <option value="">Use instance default</option>
+                                        <option value="h264">H.264</option>
+                                        <option value="av1">AV1</option>
+                                        <option value="vp9">VP9</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <div>
+                                    <label for="cobalt-youtube-video-container">YouTube container</label>
+                                    <select id="cobalt-youtube-video-container">
+                                        <option value="">Use instance default</option>
+                                        <option value="auto">Auto</option>
+                                        <option value="mp4">MP4</option>
+                                        <option value="webm">WebM</option>
+                                        <option value="mkv">MKV</option>
+                                    </select>
+                                </div>
+                                <div>
+                                    <label for="cobalt-local-processing">Local processing preference</label>
+                                    <select id="cobalt-local-processing">
+                                        <option value="">Use instance default</option>
+                                        <option value="disabled">Disabled</option>
+                                        <option value="preferred">Preferred</option>
+                                        <option value="forced">Forced</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <div>
+                                    <label for="cobalt-subtitle-lang">Subtitle language</label>
+                                    <input id="cobalt-subtitle-lang" type="text" placeholder="en" />
+                                </div>
+                                <div>
+                                    <label for="cobalt-youtube-dub-lang">YouTube dub language</label>
+                                    <input id="cobalt-youtube-dub-lang" type="text" placeholder="es" />
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <div>
+                                    <label for="cobalt-convert-gif">Twitter GIF handling</label>
+                                    <select id="cobalt-convert-gif">
+                                        <option value="">Use instance default</option>
+                                        <option value="true">Convert to GIF</option>
+                                        <option value="false">Keep as video</option>
+                                    </select>
+                                </div>
+                                <div class="checkbox-group">
+                                    <label class="checkbox">
+                                        <input id="cobalt-allow-h265" type="checkbox" />
+                                        <span>Allow H265 / HEVC (TikTok)</span>
+                                    </label>
+                                    <label class="checkbox">
+                                        <input id="cobalt-tiktok-full-audio" type="checkbox" />
+                                        <span>Fetch TikTok original audio</span>
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <label class="checkbox">
+                                    <input id="cobalt-youtube-better-audio" type="checkbox" />
+                                    <span>Prefer higher quality YouTube audio</span>
+                                </label>
+                                <label class="checkbox">
+                                    <input id="cobalt-youtube-hls" type="checkbox" />
+                                    <span>Use YouTube HLS formats</span>
+                                </label>
+                            </div>
+                            <p class="muted">Need something custom? Add extra key/value pairs or paste raw JSON below. Later values override earlier selections.</p>
+                            <div id="cobalt-custom-options" class="cobalt-options"></div>
+                            <button type="button" id="cobalt-add-option" class="text-btn">Add custom option</button>
+                            <template id="cobalt-option-template">
+                                <div class="form-row cobalt-option-row">
+                                    <input type="text" data-option-key aria-label="Option key" placeholder="option name" />
+                                    <select data-option-type aria-label="Value type">
+                                        <option value="string">Text</option>
+                                        <option value="number">Number</option>
+                                        <option value="boolean">Boolean</option>
+                                        <option value="json">JSON</option>
+                                    </select>
+                                    <input type="text" data-option-value aria-label="Option value" placeholder="value" />
+                                    <button type="button" class="text-btn" data-option-remove aria-label="Remove option">Remove</button>
+                                </div>
+                            </template>
+                            <label for="cobalt-payload">Advanced JSON payload (optional)</label>
+                            <textarea id="cobalt-payload" rows="5" placeholder='{"youtubeHLS": true, "subtitleLang": "en"}'></textarea>
                             <button type="submit" class="primary-btn">Send to Cobalt</button>
                         </form>
                     </div>


### PR DESCRIPTION
## Summary
- expand the Studio Cobalt downloader card with service override, presets, option selectors, and a custom option builder to expose the full API surface
- add front-end logic that applies presets, gathers the new controls, validates custom entries, and assembles the payload before calling `/js-tools/cobalt`
- refresh styling for the added controls and update the README to highlight the richer Studio experience

## Testing
- pytest tools-api/tests/test_js_tools.py -k cobalt

------
https://chatgpt.com/codex/tasks/task_e_68e15f18fb248328a5ae577c03f2fea8