### PR TITLE
Revamp yt-dlp inspector with guided download workflow

### DIFF
--- a/tools-api/app/static/css/studio.css
+++ b/tools-api/app/static/css/studio.css
@@ -239,6 +239,25 @@ label {
     font-size: 0.9rem;
 }
 
+select {
+    width: 100%;
+    padding: 10px 12px;
+    background: rgba(9, 15, 28, 0.75);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    font-family: inherit;
+    font-size: 0.95rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    appearance: none;
+}
+
+select:focus {
+    outline: none;
+    border-color: rgba(79, 139, 255, 0.6);
+    box-shadow: 0 0 0 4px rgba(79, 139, 255, 0.15);
+}
+
 input[type="text"],
 input[type="url"],
 input[type="number"],
@@ -269,6 +288,76 @@ input[type="file"]:focus {
 
 textarea {
     resize: vertical;
+}
+
+.helper-text {
+    margin: 6px 0 16px;
+    font-size: 0.85rem;
+    color: var(--muted);
+}
+
+.form-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    margin: 12px 0 4px;
+}
+
+.secondary-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    background: rgba(79, 139, 255, 0.18);
+    color: var(--text);
+    padding: 11px 16px;
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(79, 139, 255, 0.35);
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.secondary-btn:hover {
+    background: rgba(79, 139, 255, 0.28);
+    transform: translateY(-1px);
+}
+
+.secondary-btn:disabled {
+    background: rgba(79, 139, 255, 0.1);
+    border-color: rgba(79, 139, 255, 0.18);
+    color: rgba(255, 255, 255, 0.45);
+    cursor: not-allowed;
+    transform: none;
+}
+
+.advanced-options {
+    margin-top: 16px;
+    background: rgba(8, 13, 26, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: var(--radius-sm);
+    padding: 12px 16px;
+}
+
+.advanced-options summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--muted);
+}
+
+.advanced-options[open] summary {
+    color: var(--text);
+    margin-bottom: 12px;
+}
+
+.advanced-grid {
+    display: grid;
+    gap: 16px;
+}
+
+.advanced-options .form-row {
+    margin-top: 4px;
 }
 
 .slider-group {
@@ -380,6 +469,17 @@ textarea {
 
 .result-panel .download-link:hover {
     background: rgba(79, 139, 255, 0.3);
+}
+
+.yt-dlp-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+}
+
+.yt-dlp-actions p {
+    margin: 0;
 }
 
 .subtitle-list {
@@ -542,6 +642,141 @@ textarea {
 
 .toast.error {
     border-color: rgba(248, 113, 113, 0.5);
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal[hidden] {
+    display: none;
+}
+
+.modal__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(4, 7, 16, 0.7);
+    backdrop-filter: blur(6px);
+}
+
+.modal__dialog {
+    position: relative;
+    background: rgba(12, 19, 34, 0.95);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 28px 64px rgba(4, 8, 20, 0.5);
+    padding: 24px 28px 28px;
+    width: min(560px, 92vw);
+    max-height: 85vh;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.modal__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.modal__header h3 {
+    margin: 0 0 4px;
+}
+
+.modal__body {
+    flex: 1;
+    overflow-y: auto;
+    display: grid;
+    gap: 16px;
+    padding-right: 4px;
+}
+
+.modal__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+}
+
+.icon-btn {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: var(--text);
+    border-radius: 999px;
+    width: 32px;
+    height: 32px;
+    font-size: 1.2rem;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.icon-btn:hover {
+    border-color: rgba(255, 255, 255, 0.35);
+}
+
+.quality-list {
+    display: grid;
+    gap: 12px;
+}
+
+.quality-option {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 12px;
+    align-items: flex-start;
+    padding: 14px 16px;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.03);
+    transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.quality-option input {
+    margin-top: 4px;
+}
+
+.quality-option:hover {
+    border-color: rgba(79, 139, 255, 0.4);
+    background: rgba(79, 139, 255, 0.12);
+    transform: translateY(-1px);
+}
+
+.quality-option.is-selected {
+    border-color: rgba(79, 139, 255, 0.6);
+    background: rgba(79, 139, 255, 0.18);
+}
+
+.quality-title {
+    font-weight: 600;
+}
+
+.quality-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+    margin-top: 6px;
+    font-size: 0.85rem;
+    color: var(--muted);
+}
+
+.quality-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.quality-empty {
+    font-size: 0.9rem;
+    color: var(--muted);
+}
+
+body.modal-open {
+    overflow: hidden;
 }
 
 .muted {

--- a/tools-api/app/templates/studio.html
+++ b/tools-api/app/templates/studio.html
@@ -258,43 +258,108 @@
                         <form id="yt-dlp-form" class="tool-form">
                             <div class="form-header">
                                 <h3>yt-dlp Inspector</h3>
-                                <p class="muted">Fetch metadata or trigger a download with safe defaults.</p>
+                                <p class="muted">Preview the media details, then pick a ready-made download recipe.</p>
                             </div>
                             <label for="yt-dlp-url">URL</label>
                             <input id="yt-dlp-url" type="url" required placeholder="https://www.youtube.com/watch?v=..." />
-                            <label for="yt-dlp-format">Format selector (optional)</label>
-                            <input id="yt-dlp-format" type="text" placeholder="bestvideo+bestaudio/best" />
-                            <label for="yt-dlp-playlist-items">Playlist items (e.g. 1-3,5)</label>
-                            <input id="yt-dlp-playlist-items" type="text" placeholder="1-3,5" />
-                            <label class="checkbox">
-                                <input id="yt-dlp-binary" type="checkbox" />
-                                <span>Return binary download</span>
-                            </label>
-                            <label for="yt-dlp-filename">Filename override (binary only)</label>
-                            <input id="yt-dlp-filename" type="text" placeholder="custom.mp4" />
-                            <label for="yt-dlp-headers">HTTP headers (JSON object)</label>
-                            <textarea id="yt-dlp-headers" rows="3" placeholder='{"Cookie": "session=..."}'></textarea>
-                            <label for="yt-dlp-proxy">Proxy URL</label>
-                            <input id="yt-dlp-proxy" type="text" placeholder="socks5://localhost:9050" />
-                            <div class="form-row">
-                                <label class="checkbox">
-                                    <input id="yt-dlp-write-subtitles" type="checkbox" />
-                                    <span>Write subtitles</span>
-                                </label>
-                                <label class="checkbox">
-                                    <input id="yt-dlp-write-auto-sub" type="checkbox" />
-                                    <span>Write automatic subs</span>
-                                </label>
+
+                            <label for="yt-dlp-template">Quick recipe</label>
+                            <select id="yt-dlp-template">
+                                <option value="best">Best quality video</option>
+                                <option value="hd1080">HD 1080p (if available)</option>
+                                <option value="audio">Audio only</option>
+                                <option value="subtitles">Grab subtitles</option>
+                                <option value="custom">Custom setup</option>
+                            </select>
+                            <p id="yt-dlp-template-hint" class="helper-text"></p>
+
+                            <div class="form-actions">
+                                <button type="submit" class="primary-btn">Preview media info</button>
+                                <button type="button" id="yt-dlp-open-modal" class="secondary-btn" disabled>
+                                    Choose download quality
+                                </button>
                             </div>
-                            <label for="yt-dlp-subtitle-langs">Subtitle languages (comma separated)</label>
-                            <input id="yt-dlp-subtitle-langs" type="text" placeholder="en,es" />
-                            <button type="submit" class="primary-btn">Run yt-dlp</button>
+
+                            <details class="advanced-options">
+                                <summary>Advanced options</summary>
+                                <div class="advanced-grid">
+                                    <div>
+                                        <label for="yt-dlp-format">Format selector</label>
+                                        <input
+                                            id="yt-dlp-format"
+                                            type="text"
+                                            placeholder="bestvideo+bestaudio/best"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label for="yt-dlp-playlist-items">Playlist items (e.g. 1-3,5)</label>
+                                        <input id="yt-dlp-playlist-items" type="text" placeholder="1-3,5" />
+                                    </div>
+                                    <div>
+                                        <label for="yt-dlp-filename">Filename override</label>
+                                        <input id="yt-dlp-filename" type="text" placeholder="custom.mp4" />
+                                    </div>
+                                    <div>
+                                        <label for="yt-dlp-headers">HTTP headers (JSON object)</label>
+                                        <textarea
+                                            id="yt-dlp-headers"
+                                            rows="3"
+                                            placeholder='{"Cookie": "session=..."}'
+                                        ></textarea>
+                                    </div>
+                                    <div>
+                                        <label for="yt-dlp-proxy">Proxy URL</label>
+                                        <input id="yt-dlp-proxy" type="text" placeholder="socks5://localhost:9050" />
+                                    </div>
+                                    <div class="form-row">
+                                        <label class="checkbox">
+                                            <input id="yt-dlp-write-subtitles" type="checkbox" />
+                                            <span>Write subtitles to disk</span>
+                                        </label>
+                                        <label class="checkbox">
+                                            <input id="yt-dlp-write-auto-sub" type="checkbox" />
+                                            <span>Write automatic subs</span>
+                                        </label>
+                                    </div>
+                                    <div>
+                                        <label for="yt-dlp-subtitle-langs">Subtitle languages (comma separated)</label>
+                                        <input id="yt-dlp-subtitle-langs" type="text" placeholder="en,es" />
+                                    </div>
+                                </div>
+                            </details>
                         </form>
                     </div>
                     <div id="media-results" class="result-panel span-two" aria-live="polite"></div>
                 </div>
             </section>
         </main>
+    </div>
+    <div id="yt-dlp-modal" class="modal" hidden>
+        <div class="modal__backdrop" data-modal-dismiss></div>
+        <div class="modal__dialog" role="dialog" aria-modal="true" aria-labelledby="yt-dlp-modal-title">
+            <header class="modal__header">
+                <div>
+                    <h3 id="yt-dlp-modal-title">Choose a download quality</h3>
+                    <p id="yt-dlp-modal-subtitle" class="muted"></p>
+                </div>
+                <button type="button" class="icon-btn" id="yt-dlp-modal-close" aria-label="Close">
+                    ×
+                </button>
+            </header>
+            <div class="modal__body">
+                <p class="helper-text">
+                    Select the format that best matches what you need. We organise the list from the highest video quality to
+                    simple audio tracks.
+                </p>
+                <div id="yt-dlp-quality-list" class="quality-list" role="radiogroup" aria-label="Download options"></div>
+            </div>
+            <footer class="modal__footer">
+                <button type="button" class="secondary-btn" data-modal-dismiss>Cancel</button>
+                <button type="button" class="primary-btn" id="yt-dlp-modal-download" disabled>
+                    Download selection
+                </button>
+            </footer>
+        </div>
     </div>
     <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
     <script>


### PR DESCRIPTION
## Summary
- add a quick recipe selector and reorganised advanced controls so common yt-dlp options are one-click away
- introduce a modal quality picker with refreshed styling to guide users through choosing a download format
- overhaul the yt-dlp client logic to render friendly metadata, apply templates, and handle binary downloads from the chosen format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e15f5a03b48328bb44db299c28a7f9