### PR TITLE
Ensure before/after animations use ffmpeg writer

### DIFF
--- a/tools-api/app/services/before_after_service.py
+++ b/tools-api/app/services/before_after_service.py
@@ -106,11 +106,12 @@ class BeforeAfterService:
                 codec="libx264",
                 quality=8,
                 macro_block_size=None,
+                format="FFMPEG",
             ) as writer:
                 for array in np_frames:
                     writer.append_data(array)
             content = Path(temp_file.name).read_bytes()
-        except (RuntimeError, ValueError, OSError) as exc:  # pragma: no cover - depends on ffmpeg availability
+        except (RuntimeError, ValueError, OSError, TypeError) as exc:  # pragma: no cover - depends on ffmpeg availability
             raise BeforeAfterError("Failed to encode animation with ffmpeg") from exc
         finally:
             try:


### PR DESCRIPTION
## Summary
- force the before/after service to use the FFMPEG writer to encode MP4 animations
- guard against TypeError when encoding fails so callers receive a consistent error

## Testing
- pytest tests/test_image_tools.py::test_before_after_default_message -q

------
https://chatgpt.com/codex/tasks/task_e_68e16e31f04083288975fcbc0ac7203d