### PR TITLE
Handle missing ffmpeg plugin in before/after service

### DIFF
--- a/tools-api/app/services/before_after_service.py
+++ b/tools-api/app/services/before_after_service.py
@@ -106,12 +106,18 @@ class BeforeAfterService:
                 codec="libx264",
                 quality=8,
                 macro_block_size=None,
+                format="FFMPEG",
             ) as writer:
                 for array in np_frames:
                     writer.append_data(array)
             content = Path(temp_file.name).read_bytes()
-        except (RuntimeError, ValueError, OSError) as exc:  # pragma: no cover - depends on ffmpeg availability
-            raise BeforeAfterError("Failed to encode animation with ffmpeg") from exc
+        except (RuntimeError, ValueError, OSError, TypeError, ImportError) as exc:  # pragma: no cover - depends on ffmpeg availability
+            message = "Failed to encode animation with ffmpeg"
+            if isinstance(exc, ImportError):
+                message = (
+                    "FFmpeg support is not installed. Install imageio[ffmpeg] or supply an ffmpeg binary"
+                )
+            raise BeforeAfterError(message) from exc
         finally:
             try:
                 Path(temp_file.name).unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- convert ImportError raised by imageio when the ffmpeg plugin is missing into a user-facing BeforeAfterError
- provide actionable guidance instructing callers to install imageio[ffmpeg] or supply an ffmpeg binary when encoding cannot proceed

## Testing
- pytest tests/test_image_tools.py::test_before_after_default_message -q

------
https://chatgpt.com/codex/tasks/task_e_68e16e31f04083288975fcbc0ac7203d