### PR TITLE
Fix Studio asset URLs for deployments behind a root path

### DIFF
--- a/tools-api/app/templates/studio.html
+++ b/tools-api/app/templates/studio.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Tools API Studio</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
-    <link rel="stylesheet" href="/static/css/studio.css" />
+    <link rel="stylesheet" href="{{ request.url_for('static', path='css/studio.css').path }}" />
 </head>
 <body>
     <div class="app-shell">
@@ -609,6 +609,6 @@
             cobaltShortcuts: {{ cobalt_shortcuts | tojson }}
         };
     </script>
-    <script src="/static/js/studio.js" type="module"></script>
+    <script src="{{ request.url_for('static', path='js/studio.js').path }}" type="module"></script>
 </body>
 </html>

--- a/tools-api/tests/test_studio.py
+++ b/tools-api/tests/test_studio.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_studio_respects_root_path_for_assets_and_links():
+    client = TestClient(app, root_path="/tools")
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    html = response.text
+
+    assert 'href="/tools/static/css/studio.css"' in html
+    assert 'src="/tools/static/js/studio.js"' in html
+    assert 'href="/tools/docs"' in html
+    assert 'openapiUrl: "/tools/openapi.json"' in html


### PR DESCRIPTION
## Summary
- ensure the Studio view resolves docs and OpenAPI links against the current root path
- serve Studio assets through `url_for` so CSS and JS work when the app is mounted beneath a prefix
- cover the regression with a test that renders the Studio page behind a mocked root path

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e174651f0883288b16d734ecd3c197