### PR TITLE
Fix studio module crash when preparing yt-dlp download links

### DIFF
--- a/tools-api/app/static/js/studio.js
+++ b/tools-api/app/static/js/studio.js
@@ -1855,12 +1855,6 @@ async function handleYtDlpDownload(formatId) {
             directLabel: 'Open API download link'
         };
 
-        const directUrl = buildDirectDownloadUrl({ url: payload.url, format: formatId, filename });
-        const directLink = createDownloadLinkFromUrl(directUrl, 'Open API download link');
-        if (directLink) {
-            downloadNodes.push(directLink);
-        }
-
         if (selectedFormat) {
             const downloadMeta = {};
             downloadMeta['Format ID'] = selectedFormat.format_id;


### PR DESCRIPTION
## Summary
- remove the duplicate direct download link setup that crashed the studio JavaScript module
- allow the studio UI to initialise correctly so forms and the endpoint catalogue work again

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1778aab348328907a6faef8fab885