### PR TITLE
Add GIF fallback for before/after animations

### DIFF
--- a/tools-api/app/routers/image_tools.py
+++ b/tools-api/app/routers/image_tools.py
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/image-tools", tags=["image-tools"])
 
 
 class BeforeAfterResponse(BaseModel):
-    video_base64: str = Field(..., description="Base64 encoded MP4 animation.")
+    video_base64: str = Field(..., description="Base64 encoded animation clip (MP4 or GIF).")
     filename: str
     content_type: str
     metadata: dict
@@ -43,6 +43,7 @@ class HalationsResponse(BaseModel):
         200: {
             "content": {
                 "video/mp4": {"schema": {"type": "string", "format": "binary"}},
+                "image/gif": {"schema": {"type": "string", "format": "binary"}},
             }
         }
     },
@@ -66,7 +67,7 @@ async def before_after_endpoint(
     overlay_text: str | None = Form(None, description="Text to render when add_text is true."),
     response_format: Literal["json", "binary"] = Query(
         "json",
-        description="Return JSON with base64 video (default) or binary MP4 stream.",
+        description="Return JSON with base64 animation (default) or binary stream.",
     ),
 ):
     """Generate a before/after swipe animation."""


### PR DESCRIPTION
## Summary
- add a GIF fallback encoder for the before/after animation when ffmpeg support is unavailable and record the chosen container in metadata
- document the broader animation output types on the image tools endpoint
- adjust image tool tests to accept either MP4 or GIF outputs from the before/after generator

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e186be67748328858922a806faad76