### PR TITLE
Improve yt-dlp request handling and UX

### DIFF
--- a/tools-api/app/static/js/studio.js
+++ b/tools-api/app/static/js/studio.js
@@ -1327,16 +1327,38 @@ function setupYtDlpForm() {
     });
 }
 
+function normaliseMediaUrl(raw) {
+    if (typeof raw !== 'string') {
+        return '';
+    }
+    const trimmed = raw.trim();
+    if (!trimmed) {
+        return '';
+    }
+    if (/^https?:\/\//i.test(trimmed)) {
+        return trimmed;
+    }
+    if (trimmed.startsWith('//')) {
+        return `https:${trimmed}`;
+    }
+    return `https://${trimmed}`;
+}
+
 function buildYtDlpPayload(responseFormat, overrides = {}) {
     const dom = ytDlpState.dom || {};
     const urlField = dom.urlField;
-    const urlValue = urlField && urlField.value ? urlField.value.trim() : '';
-    if (!urlValue) {
+    const inputValue = urlField && urlField.value ? urlField.value : '';
+    const normalisedUrl = normaliseMediaUrl(inputValue);
+    if (!normalisedUrl) {
         throw new Error('Provide a URL to inspect.');
     }
 
+    if (urlField && urlField.value !== normalisedUrl) {
+        urlField.value = normalisedUrl;
+    }
+
     const payload = {
-        url: urlValue,
+        url: normalisedUrl,
         response_format: responseFormat,
         options: {
             noplaylist: true


### PR DESCRIPTION
## Summary
- normalise and sanitise yt-dlp request payloads on the API, including scheme-less URLs and filename overrides
- accept friendlier subtitle language/header inputs while keeping options strict
- auto-normalise URLs in the Studio form and expand automated tests for the media tooling

## Testing
- pytest tests/test_media.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e19c5da83c8328866632258257ddc8