### PR TITLE
Hydrate stored yt-dlp downloads for inline previews

### DIFF
--- a/tools-api/app/routers/media.py
+++ b/tools-api/app/routers/media.py
@@ -5,15 +5,16 @@ import asyncio
 import base64
 import json
 from enum import Enum
+from pathlib import Path
 from typing import Any, Dict, Literal
-from urllib.parse import quote, urlencode
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.concurrency import run_in_threadpool
 from fastapi.encoders import jsonable_encoder
-from fastapi.responses import StreamingResponse
-from pydantic import AnyHttpUrl, BaseModel, Field, constr
+from fastapi.responses import FileResponse, StreamingResponse
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, constr, field_validator
 
+from app.services.download_store import StoredDownload, download_store
 from app.services.progress_manager import progress_manager
 from app.services.yt_dlp_service import DownloadResult, YtDlpServiceError, yt_dlp_service
 from app.utils.logger import logger
@@ -21,32 +22,26 @@ from app.utils.logger import logger
 router = APIRouter(prefix="/media", tags=["media-tools"])
 
 
-class YtDlpShortcut(str, Enum):
-    """Predefined yt-dlp recipes exposed as quick API endpoints."""
+class YtDlpResponseFormat(str, Enum):
+    metadata = "metadata"
+    download = "download"
 
-    best = "best"
-    fhd = "fhd"
+
+class YtDlpDownloadMode(str, Enum):
+    video = "video"
     audio = "audio"
+    subtitles = "subtitles"
 
 
-SHORTCUT_PRESETS: Dict[YtDlpShortcut, Dict[str, Any]] = {
-    YtDlpShortcut.best: {
-        "description": "Best available video with audio merged.",
-        "options": {"format": "bestvideo*+bestaudio/best", "noplaylist": True},
-    },
-    YtDlpShortcut.fhd: {
-        "description": "1080p video when available, falling back to the closest match.",
-        "options": {"format": "bv*[height<=1080]+ba/b[height<=1080]", "noplaylist": True},
-    },
-    YtDlpShortcut.audio: {
-        "description": "Audio-only download using the best available track.",
-        "options": {"format": "bestaudio/best", "noplaylist": True},
-    },
-}
+class YtDlpSubtitleSource(str, Enum):
+    original = "original"
+    auto = "auto"
 
 
 class YtDlpOptions(BaseModel):
     """Subset of yt-dlp options exposed through the API."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
     format: str | None = Field(
         default=None, description="yt-dlp format selector, for example 'bestvideo+bestaudio/best'."
@@ -74,6 +69,45 @@ class YtDlpOptions(BaseModel):
         description="List of subtitle language codes to prioritise (yt-dlp subtitleslangs option).",
     )
 
+    @field_validator("playlist_items", "proxy", mode="before")
+    @classmethod
+    def _normalise_optional_strings(cls, value: Any):
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                return None
+        return value
+
+    @field_validator("http_headers", mode="before")
+    @classmethod
+    def _ensure_http_headers_dict(cls, value: Any):
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError as exc:
+                raise ValueError("http_headers must be a JSON object") from exc
+            if not isinstance(parsed, dict):
+                raise ValueError("http_headers must be a JSON object")
+            return parsed
+        raise ValueError("http_headers must be a mapping of header names to values")
+
+    @field_validator("subtitleslangs", mode="before")
+    @classmethod
+    def _parse_subtitle_languages(cls, value: Any):
+        if value is None:
+            return None
+        if isinstance(value, list):
+            cleaned = [str(item).strip() for item in value if str(item).strip()]
+            return cleaned or None
+        if isinstance(value, str):
+            languages = [item.strip() for item in value.split(",") if item.strip()]
+            return languages or None
+        raise ValueError("subtitleslangs must be a list of language codes or a comma separated string")
+
     def to_yt_dlp_kwargs(self) -> Dict[str, Any]:
         payload: Dict[str, Any] = {}
         if self.format:
@@ -95,14 +129,32 @@ class YtDlpOptions(BaseModel):
 
 
 class YtDlpRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
     url: AnyHttpUrl = Field(..., description="URL understood by yt-dlp.")
-    response_format: Literal["json", "binary"] = Field(
-        default="json",
-        description="Return metadata as JSON (default) or stream the downloaded media as binary.",
+    response_format: YtDlpResponseFormat = Field(
+        default=YtDlpResponseFormat.metadata,
+        description="Return metadata or persist a download for retrieval.",
     )
     filename: str | None = Field(
         default=None,
         description="Optional filename to use when returning binary content. Defaults to yt-dlp's detected name.",
+    )
+    mode: YtDlpDownloadMode | None = Field(
+        default=None,
+        description="Download mode to execute when response_format='download'.",
+    )
+    format_id: str | None = Field(
+        default=None,
+        description="Specific yt-dlp format identifier selected from metadata.",
+    )
+    subtitle_languages: list[str] | None = Field(
+        default=None,
+        description="Subtitle language codes to download when mode='subtitles'.",
+    )
+    subtitle_source: YtDlpSubtitleSource = Field(
+        default=YtDlpSubtitleSource.original,
+        description="Use original author subtitles or automatically generated captions.",
     )
     options: YtDlpOptions = Field(default_factory=YtDlpOptions, description="Advanced yt-dlp options.")
     job_id: constr(strip_whitespace=True, min_length=4, max_length=64, pattern=r"^[A-Za-z0-9_-]+$") | None = Field(
@@ -110,18 +162,81 @@ class YtDlpRequest(BaseModel):
         description="Client-supplied identifier used to stream progress updates via server-sent events.",
     )
 
+    @field_validator("url", mode="before")
+    @classmethod
+    def _normalise_url(cls, value: Any):
+        if isinstance(value, str):
+            trimmed = value.strip()
+            if not trimmed:
+                return trimmed
+            if trimmed.startswith(("http://", "https://")):
+                return trimmed
+            if trimmed.startswith("//"):
+                return f"https:{trimmed}"
+            if "://" not in trimmed:
+                return f"https://{trimmed}"
+        return value
+
+    @field_validator("filename", mode="before")
+    @classmethod
+    def _sanitise_filename(cls, value: Any):
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise ValueError("filename must be a string")
+        trimmed = value.strip()
+        if not trimmed:
+            return None
+        safe_name = Path(trimmed).name
+        if not safe_name:
+            raise ValueError("filename must contain a valid file name")
+        return safe_name
+
+    @field_validator("response_format", mode="before")
+    @classmethod
+    def _normalise_response_format(cls, value: Any):
+        if isinstance(value, str):
+            normalised = value.strip().lower()
+            if normalised in {"json", "metadata"}:
+                return YtDlpResponseFormat.metadata
+            if normalised in {"binary", "download"}:
+                return YtDlpResponseFormat.download
+        return value
+
+    @field_validator("subtitle_languages", mode="before")
+    @classmethod
+    def _parse_subtitle_list(cls, value: Any):
+        if value is None:
+            return None
+        if isinstance(value, list):
+            cleaned = [str(item).strip() for item in value if str(item).strip()]
+            return cleaned or None
+        if isinstance(value, str):
+            parts = [item.strip() for item in value.split(",") if item.strip()]
+            return parts or None
+        raise ValueError("subtitle_languages must be a list or comma separated string")
+
 
 class YtDlpMetadataResponse(BaseModel):
     metadata: Dict[str, Any]
-    shortcuts: Dict[str, str] | None = Field(
-        default=None,
-        description="Quick download URLs for common video/audio recipes.",
+    available_subtitles: Dict[str, list[str]] = Field(
+        default_factory=dict,
+        description="Convenience map listing subtitle languages grouped by source type.",
     )
 
 
-def _content_disposition(filename: str) -> str:
-    encoded = quote(filename)
-    return f"attachment; filename*=UTF-8''{encoded}"
+class YtDlpDownloadDescriptor(BaseModel):
+    id: str
+    filename: str
+    content_type: str
+    filesize: int
+    url: str
+    metadata: Dict[str, Any]
+
+
+class YtDlpDownloadResponse(BaseModel):
+    metadata: Dict[str, Any]
+    download: YtDlpDownloadDescriptor
 
 
 def _metadata_header(metadata: Dict[str, Any]) -> str:
@@ -129,40 +244,80 @@ def _metadata_header(metadata: Dict[str, Any]) -> str:
     return base64.b64encode(json_payload.encode("utf-8")).decode("utf-8")
 
 
-def _shortcut_links(url: str) -> Dict[str, str]:
-    links: Dict[str, str] = {}
-    for preset in YtDlpShortcut:
-        if preset not in SHORTCUT_PRESETS:
-            continue
-        path = router.url_path_for("yt_dlp_quick_download", preset=preset.value)
-        links[preset.value] = f"{path}?{urlencode({'url': url})}"
-    return links
+def _subtitle_language_map(metadata: Dict[str, Any]) -> Dict[str, list[str]]:
+    subtitles: Dict[str, Any] = {}
+    if isinstance(metadata.get("subtitles"), dict):
+        subtitles = metadata["subtitles"]
+
+    automatic: Dict[str, Any] = {}
+    if isinstance(metadata.get("automatic_captions"), dict):
+        automatic = metadata["automatic_captions"]
+
+    def _extract_languages(source: Dict[str, Any]) -> list[str]:
+        languages: set[str] = set()
+        for key, value in source.items():
+            if not key:
+                continue
+            languages.add(str(key))
+            if isinstance(value, dict):
+                alt = value.get("name")
+                if alt:
+                    languages.add(str(alt))
+        return sorted(languages)
+
+    payload: Dict[str, list[str]] = {}
+    original = _extract_languages(subtitles)
+    if original:
+        payload[YtDlpSubtitleSource.original.value] = original
+    automatic_languages = _extract_languages(automatic)
+    if automatic_languages:
+        payload[YtDlpSubtitleSource.auto.value] = automatic_languages
+    return payload
 
 
-@router.post("/yt-dlp", response_model=YtDlpMetadataResponse)
-async def yt_dlp_endpoint(request: YtDlpRequest):
-    """Fetch metadata or download media using yt-dlp with safe defaults."""
+async def _handle_download(request: YtDlpRequest, url: str, options: Dict[str, Any], http_request: Request) -> YtDlpDownloadResponse:
+    mode = request.mode or YtDlpDownloadMode.video
+    progress_job_id = request.job_id
 
-    url = str(request.url)
-    options = request.options.to_yt_dlp_kwargs()
+    if mode != YtDlpDownloadMode.subtitles and request.format_id:
+        options["format"] = request.format_id
+    elif mode == YtDlpDownloadMode.video:
+        options.setdefault("format", "bestvideo*+bestaudio/best")
+    elif mode == YtDlpDownloadMode.audio:
+        options.setdefault("format", "bestaudio/best")
+
+    progress_callback = None
+    if progress_job_id:
+        progress_manager.ensure_channel(progress_job_id)
+        progress_manager.publish(
+            progress_job_id,
+            {"type": "progress", "stage": "starting", "message": "Preparing download"},
+        )
+
+        def _progress_forwarder(event: Dict[str, Any]) -> None:
+            progress_manager.publish(progress_job_id, event)
+
+        progress_callback = _progress_forwarder
 
     try:
-        if request.response_format == "binary":
-            progress_job_id = request.job_id
-            progress_callback = None
+        if mode == YtDlpDownloadMode.subtitles:
+            subtitle_options = dict(options)
+            if request.subtitle_languages:
+                subtitle_options["subtitleslangs"] = request.subtitle_languages
+            if request.subtitle_source == YtDlpSubtitleSource.auto:
+                subtitle_options["writeautomaticsub"] = True
+                subtitle_options.pop("writesubtitles", None)
+            else:
+                subtitle_options["writesubtitles"] = True
+                subtitle_options.pop("writeautomaticsub", None)
 
-            if progress_job_id:
-                progress_manager.ensure_channel(progress_job_id)
-                progress_manager.publish(
-                    progress_job_id,
-                    {"type": "progress", "stage": "starting", "message": "Preparing download"},
-                )
-
-                def _progress_forwarder(event: Dict[str, Any]) -> None:
-                    progress_manager.publish(progress_job_id, event)
-
-                progress_callback = _progress_forwarder
-
+            download = await run_in_threadpool(
+                yt_dlp_service.download_subtitles,
+                url,
+                options=subtitle_options,
+                filename_override=request.filename,
+            )
+        else:
             download_kwargs: Dict[str, Any] = {
                 "options": options,
                 "filename_override": request.filename,
@@ -170,112 +325,117 @@ async def yt_dlp_endpoint(request: YtDlpRequest):
             if progress_callback is not None:
                 download_kwargs["progress_callback"] = progress_callback
 
-            try:
-                download: DownloadResult = await run_in_threadpool(
-                    yt_dlp_service.download,
-                    url,
-                    **download_kwargs,
-                )
-            except YtDlpServiceError as exc:
-                if progress_job_id:
-                    progress_manager.publish(
-                        progress_job_id,
-                        {"type": "error", "stage": "failed", "message": str(exc)},
-                    )
-                logger.error("yt-dlp request failed: %s", exc)
-                raise HTTPException(status_code=502, detail=str(exc)) from exc
-            except Exception as exc:  # pragma: no cover - guard against unexpected failures
-                if progress_job_id:
-                    progress_manager.publish(
-                        progress_job_id,
-                        {"type": "error", "stage": "failed", "message": "Download failed"},
-                    )
-                logger.exception("Unexpected yt-dlp failure")
-                raise
-            else:
-                if progress_job_id:
-                    progress_manager.publish(
-                        progress_job_id,
-                        {"type": "progress", "stage": "packaging", "message": "Packaging download"},
-                    )
-                    progress_manager.publish(
-                        progress_job_id,
-                        {"type": "complete", "stage": "ready", "message": "Download ready"},
-                    )
-            finally:
-                if progress_job_id:
-                    progress_manager.close(progress_job_id)
+            download = await run_in_threadpool(
+                yt_dlp_service.download,
+                url,
+                **download_kwargs,
+            )
+    except YtDlpServiceError as exc:
+        if progress_job_id:
+            progress_manager.publish(
+                progress_job_id,
+                {"type": "error", "stage": "failed", "message": str(exc)},
+            )
+        logger.error("yt-dlp request failed: %s", exc)
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - guard against unexpected failures
+        if progress_job_id:
+            progress_manager.publish(
+                progress_job_id,
+                {"type": "error", "stage": "failed", "message": "Download failed"},
+            )
+        logger.exception("Unexpected yt-dlp failure")
+        raise
+    else:
+        if progress_job_id:
+            progress_manager.publish(
+                progress_job_id,
+                {"type": "progress", "stage": "packaging", "message": "Packaging download"},
+            )
+            progress_manager.publish(
+                progress_job_id,
+                {"type": "complete", "stage": "ready", "message": "Download ready"},
+            )
+    finally:
+        if progress_job_id:
+            progress_manager.close(progress_job_id)
 
-            headers = {
-                "Content-Disposition": _content_disposition(download.filename),
-                "X-YtDlp-Metadata": _metadata_header(download.metadata),
-            }
-            return _BinaryResponse(download, headers)
+    download.metadata = download.metadata or {}
+    download.metadata.setdefault("mode", mode.value)
+
+    stored = _persist_download(download)
+    return _build_download_response(stored, download.metadata, http_request)
+
+
+def _persist_download(download: DownloadResult) -> StoredDownload:
+    metadata = dict(jsonable_encoder(download.metadata or {}))
+    metadata.setdefault("filename", download.filename)
+    metadata.setdefault("content_type", download.content_type)
+    metadata.setdefault("filesize", len(download.content))
+    stored = download_store.store(
+        filename=download.filename,
+        content=download.content,
+        content_type=download.content_type,
+        metadata=metadata,
+    )
+    return stored
+
+
+def _build_download_response(stored: StoredDownload, metadata: Dict[str, Any], request: Request) -> YtDlpDownloadResponse:
+    download_url = str(request.url_for("yt_dlp_download_file", file_id=stored.file_id))
+    download_payload = YtDlpDownloadDescriptor(
+        id=stored.file_id,
+        filename=stored.filename,
+        content_type=stored.content_type,
+        filesize=stored.path.stat().st_size,
+        url=download_url,
+        metadata=jsonable_encoder(stored.metadata),
+    )
+    return YtDlpDownloadResponse(
+        metadata=jsonable_encoder(metadata),
+        download=download_payload,
+    )
+
+
+@router.get("/yt-dlp/files/{file_id}")
+async def yt_dlp_download_file(file_id: str):
+    try:
+        stored = download_store.retrieve(file_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Download not found") from exc
+
+    response = FileResponse(
+        stored.path,
+        media_type=stored.content_type,
+        filename=stored.filename,
+    )
+    response.headers["X-YtDlp-Metadata"] = _metadata_header(stored.metadata)
+    return response
+
+
+@router.post("/yt-dlp", response_model=YtDlpMetadataResponse | YtDlpDownloadResponse)
+async def yt_dlp_endpoint(payload: YtDlpRequest, request: Request):
+    """Fetch metadata or persist media downloads using yt-dlp with safe defaults."""
+
+    url = str(payload.url)
+    options = payload.options.to_yt_dlp_kwargs()
+
+    try:
+        if payload.response_format == YtDlpResponseFormat.download:
+            if payload.mode is None:
+                raise HTTPException(status_code=400, detail="Download mode is required for downloads")
+
+            return await _handle_download(payload, url, options, request)
 
         metadata = await run_in_threadpool(yt_dlp_service.extract_info, url, options=options)
-        shortcuts = _shortcut_links(url)
-        return YtDlpMetadataResponse(metadata=jsonable_encoder(metadata), shortcuts=shortcuts)
+        available_subtitles = _subtitle_language_map(metadata)
+        return YtDlpMetadataResponse(
+            metadata=jsonable_encoder(metadata),
+            available_subtitles=available_subtitles,
+        )
     except YtDlpServiceError as exc:
         logger.error("yt-dlp request failed: %s", exc)
         raise HTTPException(status_code=502, detail=str(exc)) from exc
-
-
-@router.get("/yt-dlp/quick/{preset}")
-async def yt_dlp_quick_download(preset: YtDlpShortcut, url: AnyHttpUrl, filename: str | None = None):
-    """Download media using a predefined shortcut recipe."""
-
-    config = SHORTCUT_PRESETS.get(preset)
-    if not config:
-        raise HTTPException(status_code=404, detail="Unknown yt-dlp shortcut preset.")
-
-    options = dict(config.get("options", {}))
-
-    try:
-        download: DownloadResult = await run_in_threadpool(
-            yt_dlp_service.download,
-            str(url),
-            options=options,
-            filename_override=filename,
-        )
-    except YtDlpServiceError as exc:
-        logger.error("yt-dlp quick preset %s failed: %s", preset.value, exc)
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
-
-    headers = {
-        "Content-Disposition": _content_disposition(download.filename),
-        "X-YtDlp-Metadata": _metadata_header(download.metadata),
-    }
-    return _BinaryResponse(download, headers)
-
-
-@router.get("/yt-dlp/direct")
-async def yt_dlp_direct_download(url: AnyHttpUrl, format: str, filename: str | None = None):
-    """Download media by specifying a yt-dlp format selector directly via query string."""
-
-    options = {"format": format, "noplaylist": True}
-
-    try:
-        download: DownloadResult = await run_in_threadpool(
-            yt_dlp_service.download,
-            str(url),
-            options=options,
-            filename_override=filename,
-        )
-    except YtDlpServiceError as exc:
-        logger.error("yt-dlp direct download failed: %s", exc)
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
-
-    headers = {
-        "Content-Disposition": _content_disposition(download.filename),
-        "X-YtDlp-Metadata": _metadata_header(download.metadata),
-    }
-    return _BinaryResponse(download, headers)
-
-
-def _BinaryResponse(result: DownloadResult, headers: Dict[str, str]):
-    from fastapi import Response
-
-    return Response(content=result.content, media_type=result.content_type, headers=headers)
 
 
 @router.get("/yt-dlp/progress/{job_id}")

--- a/tools-api/app/services/download_store.py
+++ b/tools-api/app/services/download_store.py
@@ -1,0 +1,104 @@
+"""Lightweight on-disk storage for generated media downloads."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+from uuid import uuid4
+
+from app.utils.logger import logger
+
+
+@dataclass
+class StoredDownload:
+    """Metadata describing a file persisted by :class:`DownloadStore`."""
+
+    file_id: str
+    path: Path
+    filename: str
+    content_type: str
+    metadata: Dict[str, Any]
+
+
+class DownloadStore:
+    """Persist yt-dlp downloads so they can be fetched via stable URLs."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        base_path = root or self._default_root()
+        self.root = base_path
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def _default_root() -> Path:
+        """Resolve the default storage path inside the application directory."""
+
+        base_env = os.getenv("MEDIA_DOWNLOAD_DIR")
+        if base_env:
+            candidate = Path(base_env).expanduser()
+            return candidate
+
+        return Path(__file__).resolve().parents[1] / "downloads"
+
+    def store(self, *, filename: str, content: bytes, content_type: str, metadata: Dict[str, Any]) -> StoredDownload:
+        """Persist a binary payload and return the structured descriptor."""
+
+        file_id = uuid4().hex
+        target_dir = self.root / file_id
+        target_dir.mkdir(parents=True, exist_ok=False)
+
+        safe_name = Path(filename).name or "download.bin"
+        file_path = target_dir / safe_name
+        file_path.write_bytes(content)
+
+        metadata_path = target_dir / "metadata.json"
+        metadata_payload = json.dumps(metadata, ensure_ascii=False, default=str)
+        metadata_path.write_text(metadata_payload, encoding="utf-8")
+
+        logger.debug("Stored download %s at %s", file_id, file_path)
+
+        return StoredDownload(
+            file_id=file_id,
+            path=file_path,
+            filename=safe_name,
+            content_type=content_type or "application/octet-stream",
+            metadata=metadata,
+        )
+
+    def retrieve(self, file_id: str) -> StoredDownload:
+        """Load a stored download descriptor or raise :class:`FileNotFoundError`."""
+
+        target_dir = self.root / file_id
+        if not target_dir.exists() or not target_dir.is_dir():
+            raise FileNotFoundError(f"Download {file_id!r} not found")
+
+        files = [path for path in target_dir.iterdir() if path.is_file() and path.name != "metadata.json"]
+        if not files:
+            raise FileNotFoundError(f"Download {file_id!r} is missing content")
+
+        file_path = files[0]
+        metadata_path = target_dir / "metadata.json"
+        metadata: Dict[str, Any] = {}
+        if metadata_path.exists():
+            try:
+                metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                logger.warning("Metadata for %s is not valid JSON", file_id)
+
+        content_type = metadata.get("content_type") or "application/octet-stream"
+        original_name = metadata.get("filename") or file_path.name
+
+        return StoredDownload(
+            file_id=file_id,
+            path=file_path,
+            filename=original_name,
+            content_type=content_type,
+            metadata=metadata,
+        )
+
+
+download_store = DownloadStore()
+
+__all__ = ["download_store", "DownloadStore", "StoredDownload"]
+

--- a/tools-api/app/services/yt_dlp_service.py
+++ b/tools-api/app/services/yt_dlp_service.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 import base64
+import io
 import json
 import mimetypes
 import tempfile
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, List
 
 from app.utils.logger import logger
 
@@ -24,6 +26,9 @@ class DownloadResult:
     filename: str
     content_type: str
     metadata: Dict[str, Any]
+
+
+SUBTITLE_EXTENSIONS = {".vtt", ".srt", ".ass", ".lrc", ".ttml", ".json"}
 
 
 def _ensure_yt_dlp() -> Any:
@@ -149,6 +154,75 @@ class YtDlpService:
             metadata = self._serializable_metadata(info)
 
             return DownloadResult(content=content, filename=filename, content_type=content_type, metadata=metadata)
+
+    def download_subtitles(
+        self,
+        url: str,
+        *,
+        options: Dict[str, Any],
+        filename_override: str | None = None,
+    ) -> DownloadResult:
+        """Download only subtitle tracks and package them for delivery."""
+
+        yt_dlp = _ensure_yt_dlp()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            merged_options = self._build_options(
+                {
+                    "skip_download": True,
+                    "outtmpl": str(tmp_path / "%(title)s.%(ext)s"),
+                    **options,
+                }
+            )
+
+            logger.debug("Downloading subtitles via yt-dlp for %s with options %s", url, merged_options)
+            try:
+                with yt_dlp.YoutubeDL(merged_options) as ydl:
+                    info = ydl.extract_info(url, download=True)
+            except Exception as exc:  # pragma: no cover - yt-dlp raises many custom errors
+                logger.error("yt-dlp subtitle download failed: %s", exc)
+                raise YtDlpServiceError(str(exc)) from exc
+
+            subtitle_files = self._collect_subtitle_files(tmp_path)
+            if not subtitle_files:
+                logger.error("yt-dlp did not produce any subtitle files")
+                raise YtDlpServiceError("No subtitles were downloaded for this request")
+
+            if len(subtitle_files) == 1:
+                subtitle_path = subtitle_files[0]
+                filename = filename_override or subtitle_path.name
+                content = subtitle_path.read_bytes()
+                content_type = mimetypes.guess_type(filename)[0] or "text/plain"
+            else:
+                archive = io.BytesIO()
+                with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+                    for subtitle_path in subtitle_files:
+                        zip_file.write(subtitle_path, arcname=subtitle_path.name)
+                filename = filename_override or "subtitles.zip"
+                content = archive.getvalue()
+                content_type = "application/zip"
+
+            metadata = self._serializable_metadata(info)
+            metadata.update(
+                {
+                    "subtitle_files": [path.name for path in subtitle_files],
+                    "mode": "subtitles",
+                }
+            )
+
+            return DownloadResult(content=content, filename=filename, content_type=content_type, metadata=metadata)
+
+    def _collect_subtitle_files(self, directory: Path) -> List[Path]:
+        files: List[Path] = []
+        for path in directory.iterdir():
+            if not path.is_file():
+                continue
+            if path.name == "metadata.json":
+                continue
+            if path.suffix.lower() in SUBTITLE_EXTENSIONS:
+                files.append(path)
+        return files
 
     def _normalise_progress_payload(self, payload: Dict[str, Any]) -> Dict[str, Any] | None:
         """Convert yt-dlp progress dictionaries into JSON serialisable summaries."""

--- a/tools-api/app/static/css/studio.css
+++ b/tools-api/app/static/css/studio.css
@@ -298,6 +298,10 @@ textarea {
     color: var(--muted);
 }
 
+.helper-text.is-error {
+    color: var(--danger);
+}
+
 .status-banner {
     display: flex;
     align-items: center;
@@ -688,6 +692,23 @@ textarea {
     background: rgba(0, 0, 0, 0.25);
 }
 
+.media-preview {
+    display: grid;
+    gap: 8px;
+}
+
+.media-preview__video,
+.media-preview__audio {
+    width: 100%;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(0, 0, 0, 0.45);
+}
+
+.media-preview__audio {
+    padding: 12px;
+}
+
 .slice-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
@@ -738,6 +759,92 @@ textarea {
     margin: 4px 0 0;
 }
 
+.pill-toggle {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.pill-option {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+
+.pill-option input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.pill-option span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 14px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    background: rgba(255, 255, 255, 0.06);
+    font-size: 0.85rem;
+    color: var(--muted);
+    transition: background 0.2s ease, border 0.2s ease, color 0.2s ease;
+}
+
+.pill-option input:checked + span {
+    background: rgba(79, 139, 255, 0.2);
+    border-color: rgba(79, 139, 255, 0.5);
+    color: var(--text);
+}
+
+.subtitle-controls {
+    display: grid;
+    gap: 12px;
+    margin-top: 12px;
+    padding: 14px 16px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-sm);
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.subtitle-controls .field-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: center;
+}
+
+.subtitle-controls .radio {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85rem;
+}
+
+.subtitle-controls select {
+    width: 100%;
+    min-height: 140px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    padding: 8px 10px;
+    font-size: 0.85rem;
+}
+
+.field-group {
+    display: grid;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.field-group .field-label {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--muted);
+}
+
 .yt-dlp-subtitle-filter {
     display: flex;
     align-items: center;
@@ -753,36 +860,6 @@ textarea {
     color: var(--text);
     padding: 6px 10px;
     font-size: 0.85rem;
-}
-
-.yt-dlp-shortcuts {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    align-items: center;
-}
-
-.yt-dlp-shortcuts span {
-    font-size: 0.85rem;
-    color: var(--muted);
-}
-
-.yt-dlp-shortcuts a {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 6px 12px;
-    border-radius: 999px;
-    background: rgba(79, 139, 255, 0.12);
-    border: 1px solid rgba(79, 139, 255, 0.35);
-    color: var(--text);
-    font-size: 0.8rem;
-    text-decoration: none;
-    transition: background 0.2s ease;
-}
-
-.yt-dlp-shortcuts a:hover {
-    background: rgba(79, 139, 255, 0.22);
 }
 
 .download-progress {

--- a/tools-api/app/static/js/studio.js
+++ b/tools-api/app/static/js/studio.js
@@ -7,16 +7,21 @@ const ytDlpState = {
     rawResponse: null,
     formatsById: new Map(),
     dom: {},
-    lastTemplate: 'best',
     modalKeyListener: null,
     selectedFormatId: null,
-    subtitleLanguageFilter: 'en',
+    subtitleLanguageFilter: 'all',
+    selectedSubtitleSource: 'original',
+    selectedSubtitleLanguages: [],
+    availableSubtitles: { original: [], auto: [] },
+    mode: 'video',
     downloadNodes: null,
     downloadProgress: null,
     downloadProgressTimer: null,
     progressSource: null,
     currentJobId: null
 };
+
+const YT_DLP_PREVIEW_SIZE_LIMIT = 75 * 1024 * 1024;
 
 const COBALT_FIELD_IDS = {
     service: 'cobalt-service',
@@ -55,12 +60,6 @@ const languageDisplayNames =
     typeof Intl !== 'undefined' && typeof Intl.DisplayNames === 'function'
         ? new Intl.DisplayNames(['en'], { type: 'language' })
         : null;
-
-const YT_DLP_SHORTCUT_LABELS = {
-    best: 'Best available',
-    fhd: '1080p video',
-    audio: 'Audio only'
-};
 
 function init() {
     setupNavigation();
@@ -1155,8 +1154,9 @@ function setupYtDlpForm() {
     const writeSubtitlesToggle = document.getElementById('yt-dlp-write-subtitles');
     const writeAutoSubToggle = document.getElementById('yt-dlp-write-auto-sub');
     const subtitleLangsField = document.getElementById('yt-dlp-subtitle-langs');
-    const templateSelect = document.getElementById('yt-dlp-template');
-    const templateHint = document.getElementById('yt-dlp-template-hint');
+    const modeToggle = document.getElementById('yt-dlp-mode-toggle');
+    const subtitleControls = document.getElementById('yt-dlp-subtitle-controls');
+    const subtitleLanguageList = document.getElementById('yt-dlp-subtitle-language-list');
     const openModalButton = document.getElementById('yt-dlp-open-modal');
     const modal = document.getElementById('yt-dlp-modal');
     const modalSubtitle = document.getElementById('yt-dlp-modal-subtitle');
@@ -1179,8 +1179,9 @@ function setupYtDlpForm() {
         writeSubtitlesToggle,
         writeAutoSubToggle,
         subtitleLangsField,
-        templateSelect,
-        templateHint,
+        modeToggle,
+        subtitleControls,
+        subtitleLanguageList,
         openModalButton,
         modal,
         modalSubtitle,
@@ -1189,80 +1190,40 @@ function setupYtDlpForm() {
         progressContainer,
         progressLabel,
         progressPercent,
-        progressIndicator
+        progressIndicator,
+        downloadActionButton: null
     };
 
-    const templatePresets = {
-        best: {
-            description: 'Ideal when you want the highest quality video with audio.',
-            values: {
-                format: 'bestvideo*+bestaudio/best',
-                writeSubtitles: false,
-                writeAutoSub: false,
-                subtitleLangs: ''
-            }
-        },
-        hd1080: {
-            description: 'Prefer 1080p (or the best available below it) with merged audio.',
-            values: {
-                format: 'bv*[height<=1080]+ba/b[height<=1080]',
-                writeSubtitles: false,
-                writeAutoSub: false
-            }
-        },
-        audio: {
-            description: 'Grab the best available audio track without video.',
-            values: {
-                format: 'bestaudio/best',
-                writeSubtitles: false,
-                writeAutoSub: false
-            }
-        },
-        subtitles: {
-            description: 'Download metadata while preparing subtitle files for offline viewing.',
-            values: {
-                format: 'best',
-                writeSubtitles: true,
-                writeAutoSub: true
-            }
-        },
-        custom: {
-            description: 'Keep full control of every yt-dlp option yourself.'
-        }
-    };
-
-    function applyTemplateChoice(id, applyValues = true) {
-        const preset = templatePresets[id] || templatePresets.best;
-        ytDlpState.lastTemplate = id;
-        if (templateHint) {
-            templateHint.textContent = preset.description;
-        }
-        if (!applyValues || !preset.values) {
-            return;
-        }
-        const values = preset.values;
-        if (formatField && Object.prototype.hasOwnProperty.call(values, 'format')) {
-            formatField.value = values.format || '';
-        }
-        if (writeSubtitlesToggle && Object.prototype.hasOwnProperty.call(values, 'writeSubtitles')) {
-            writeSubtitlesToggle.checked = Boolean(values.writeSubtitles);
-        }
-        if (writeAutoSubToggle && Object.prototype.hasOwnProperty.call(values, 'writeAutoSub')) {
-            writeAutoSubToggle.checked = Boolean(values.writeAutoSub);
-        }
-        if (subtitleLangsField && Object.prototype.hasOwnProperty.call(values, 'subtitleLangs')) {
-            subtitleLangsField.value = values.subtitleLangs || '';
-        }
+    if (modeToggle) {
+        const modeRadios = modeToggle.querySelectorAll('input[name="yt-dlp-mode"]');
+        modeRadios.forEach((radio) => {
+            radio.addEventListener('change', () => {
+                if (!radio.checked) {
+                    return;
+                }
+                ytDlpState.mode = radio.value;
+                refreshYtDlpMode();
+            });
+        });
     }
 
-    if (templateSelect) {
-        templateSelect.addEventListener('change', () => {
-            applyTemplateChoice(templateSelect.value);
+    if (subtitleControls) {
+        subtitleControls.querySelectorAll('input[name="yt-dlp-subtitle-source"]').forEach((radio) => {
+            radio.addEventListener('change', () => {
+                if (!radio.checked) {
+                    return;
+                }
+                ytDlpState.selectedSubtitleSource = radio.value;
+                syncSubtitleLanguageSelection();
+            });
         });
-        if (!templateSelect.value) {
-            templateSelect.value = 'best';
-        }
-        applyTemplateChoice(templateSelect.value, true);
+    }
+
+    if (subtitleLanguageList) {
+        subtitleLanguageList.addEventListener('change', () => {
+            const selections = Array.from(subtitleLanguageList.selectedOptions).map((option) => option.value);
+            ytDlpState.selectedSubtitleLanguages = selections;
+        });
     }
 
     if (openModalButton) {
@@ -1294,6 +1255,10 @@ function setupYtDlpForm() {
 
     if (modalDownloadButton) {
         modalDownloadButton.addEventListener('click', () => {
+            if (ytDlpState.mode === 'subtitles') {
+                handleYtDlpDownload(null);
+                return;
+            }
             if (!qualityList) {
                 return;
             }
@@ -1307,7 +1272,7 @@ function setupYtDlpForm() {
     }
 
     attachSubmit('yt-dlp-form', async () => {
-        const payload = buildYtDlpPayload('json');
+        const payload = buildYtDlpPayload('metadata');
         const response = await fetch('/media/yt-dlp', {
             method: 'POST',
             headers: {
@@ -1321,29 +1286,186 @@ function setupYtDlpForm() {
         }
         ytDlpState.metadata = result.metadata;
         ytDlpState.rawResponse = result;
+        ytDlpState.availableSubtitles = result.available_subtitles || { original: [], auto: [] };
+        syncSubtitleLanguageSelection();
         renderYtDlpResults({ metadata: result.metadata, raw: result });
         setDownloadButtonsState(Array.isArray(result.metadata.formats) && result.metadata.formats.length > 0);
         showToast('Metadata retrieved successfully.');
     });
+
+    refreshYtDlpMode();
+}
+
+function refreshYtDlpMode() {
+    const dom = ytDlpState.dom || {};
+    const mode = ytDlpState.mode || 'video';
+    const openModalButton = dom.openModalButton;
+    const modalDownloadButton = dom.modalDownloadButton;
+    const subtitleControls = dom.subtitleControls;
+
+    if (subtitleControls) {
+        subtitleControls.hidden = mode !== 'subtitles';
+    }
+
+    if (openModalButton) {
+        openModalButton.textContent = mode === 'audio' ? 'Choose audio quality' : 'Choose download quality';
+        openModalButton.disabled = mode === 'subtitles' || !hasFormatsForCurrentMode();
+    }
+
+    if (modalDownloadButton) {
+        modalDownloadButton.textContent = mode === 'subtitles' ? 'Download subtitles' : 'Download selection';
+    }
+
+    setDownloadButtonsState(hasFormatsForCurrentMode());
+    if (mode === 'subtitles') {
+        syncSubtitleLanguageSelection();
+    }
+}
+
+function hasFormatsForCurrentMode() {
+    const metadata = ytDlpState.metadata;
+    if (!metadata || !Array.isArray(metadata.formats)) {
+        return false;
+    }
+    const mode = ytDlpState.mode || 'video';
+    return metadata.formats.some((format) => {
+        if (!format || typeof format !== 'object') {
+            return false;
+        }
+        if (mode === 'audio') {
+            return isAudioFormat(format);
+        }
+        if (mode === 'video') {
+            return isVideoFormat(format);
+        }
+        return false;
+    });
+}
+
+function syncSubtitleLanguageSelection() {
+    const dom = ytDlpState.dom || {};
+    const list = dom.subtitleLanguageList;
+    if (!list) {
+        return;
+    }
+
+    const availableSources = Object.entries(ytDlpState.availableSubtitles || {})
+        .filter(([, values]) => Array.isArray(values) && values.length)
+        .map(([key]) => key);
+    if (!availableSources.length) {
+        ytDlpState.selectedSubtitleLanguages = [];
+    }
+
+    if (!availableSources.includes(ytDlpState.selectedSubtitleSource)) {
+        ytDlpState.selectedSubtitleSource = availableSources[0] || 'original';
+    }
+
+    if (dom.subtitleControls) {
+        dom.subtitleControls
+            .querySelectorAll('input[name="yt-dlp-subtitle-source"]')
+            .forEach((radio) => {
+                radio.checked = radio.value === ytDlpState.selectedSubtitleSource;
+                radio.disabled = availableSources.length > 0 && !availableSources.includes(radio.value);
+            });
+    }
+
+    const source = ytDlpState.selectedSubtitleSource || 'original';
+    const available = ytDlpState.availableSubtitles[source] || [];
+    const previous = new Set(ytDlpState.selectedSubtitleLanguages || []);
+
+    list.innerHTML = '';
+
+    if (!available.length) {
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'No subtitles available yet';
+        placeholder.disabled = true;
+        placeholder.selected = true;
+        list.appendChild(placeholder);
+        list.disabled = true;
+        ytDlpState.selectedSubtitleLanguages = [];
+        return;
+    }
+
+    list.disabled = false;
+    available.forEach((code) => {
+        const option = document.createElement('option');
+        option.value = code;
+        option.textContent = createLanguageOptionLabel(code);
+        option.selected = previous.size ? previous.has(code) : false;
+        list.appendChild(option);
+    });
+
+    if (!previous.size) {
+        ytDlpState.selectedSubtitleLanguages = [];
+    }
+}
+
+function normaliseDownloadMetadata(raw) {
+    if (!raw || typeof raw !== 'object') {
+        return {};
+    }
+    const skip = new Set(['filename', 'contentType', 'content_type', 'filesize']);
+    return Object.entries(raw).reduce((acc, [key, value]) => {
+        if (skip.has(key)) {
+            return acc;
+        }
+        if (value === null || value === undefined) {
+            return acc;
+        }
+        if (typeof value === 'object') {
+            try {
+                acc[key] = JSON.stringify(value);
+            } catch (error) {
+                acc[key] = String(value);
+            }
+        } else {
+            acc[key] = String(value);
+        }
+        return acc;
+    }, {});
+}
+
+function normaliseMediaUrl(raw) {
+    if (typeof raw !== 'string') {
+        return '';
+    }
+    const trimmed = raw.trim();
+    if (!trimmed) {
+        return '';
+    }
+    if (/^https?:\/\//i.test(trimmed)) {
+        return trimmed;
+    }
+    if (trimmed.startsWith('//')) {
+        return `https:${trimmed}`;
+    }
+    return `https://${trimmed}`;
 }
 
 function buildYtDlpPayload(responseFormat, overrides = {}) {
     const dom = ytDlpState.dom || {};
     const urlField = dom.urlField;
-    const urlValue = urlField && urlField.value ? urlField.value.trim() : '';
-    if (!urlValue) {
+    const inputValue = urlField && urlField.value ? urlField.value : '';
+    const normalisedUrl = normaliseMediaUrl(inputValue);
+    if (!normalisedUrl) {
         throw new Error('Provide a URL to inspect.');
     }
 
+    if (urlField && urlField.value !== normalisedUrl) {
+        urlField.value = normalisedUrl;
+    }
+
     const payload = {
-        url: urlValue,
+        url: normalisedUrl,
         response_format: responseFormat,
+        mode: ytDlpState.mode || 'video',
         options: {
             noplaylist: true
         }
     };
 
-    if (responseFormat === 'binary' && dom.filenameField && dom.filenameField.value.trim()) {
+    if (responseFormat === 'download' && dom.filenameField && dom.filenameField.value.trim()) {
         payload.filename = dom.filenameField.value.trim();
     }
 
@@ -1357,6 +1479,10 @@ function buildYtDlpPayload(responseFormat, overrides = {}) {
                 : '';
     if (formatValue) {
         payload.options.format = formatValue;
+    }
+
+    if (responseFormat === 'download' && typeof formatOverride === 'string' && formatOverride.trim().length) {
+        payload.format_id = formatOverride.trim();
     }
 
     if (dom.playlistItemsField && dom.playlistItemsField.value.trim()) {
@@ -1397,6 +1523,13 @@ function buildYtDlpPayload(responseFormat, overrides = {}) {
         }
     }
 
+    if (responseFormat === 'download' && ytDlpState.mode === 'subtitles') {
+        payload.subtitle_source = ytDlpState.selectedSubtitleSource || 'original';
+        if (Array.isArray(ytDlpState.selectedSubtitleLanguages) && ytDlpState.selectedSubtitleLanguages.length) {
+            payload.subtitle_languages = ytDlpState.selectedSubtitleLanguages;
+        }
+    }
+
     if (overrides.options && typeof overrides.options === 'object') {
         payload.options = { ...payload.options, ...overrides.options };
     }
@@ -1418,6 +1551,9 @@ function renderYtDlpResults(args = {}) {
         ytDlpState.metadata = null;
         ytDlpState.rawResponse = null;
         ytDlpState.downloadNodes = null;
+        if (ytDlpState.dom) {
+            ytDlpState.dom.downloadActionButton = null;
+        }
         setResult('media-results', []);
         setDownloadButtonsState(false);
         return;
@@ -1430,6 +1566,8 @@ function renderYtDlpResults(args = {}) {
     } else if (ytDlpState.rawResponse) {
         raw = ytDlpState.rawResponse;
     }
+
+    syncSubtitleLanguageSelection();
 
     if (download !== undefined) {
         ytDlpState.downloadNodes = download;
@@ -1483,9 +1621,10 @@ function renderYtDlpResults(args = {}) {
         summaryNodes.push(createMetaGrid(summaryMeta));
     }
 
-    if (metadata.thumbnail) {
+    const thumbnailUrl = selectBestThumbnail(metadata);
+    if (thumbnailUrl) {
         const thumbnail = document.createElement('img');
-        thumbnail.src = metadata.thumbnail;
+        thumbnail.src = thumbnailUrl;
         thumbnail.alt = metadata.title ? `${metadata.title} thumbnail` : 'Media thumbnail';
         summaryNodes.push(thumbnail);
     }
@@ -1495,10 +1634,26 @@ function renderYtDlpResults(args = {}) {
     const chooseButton = document.createElement('button');
     chooseButton.type = 'button';
     chooseButton.className = 'secondary-btn';
-    chooseButton.textContent = 'Choose download quality';
-    chooseButton.disabled = !hasFormats;
+    chooseButton.textContent = ytDlpState.mode === 'audio' ? 'Choose audio quality' : 'Choose download quality';
+    chooseButton.disabled = ytDlpState.mode === 'subtitles' ? true : !hasFormatsForCurrentMode();
     chooseButton.addEventListener('click', () => openYtDlpModal());
     actions.appendChild(chooseButton);
+
+    const downloadNowButton = document.createElement('button');
+    downloadNowButton.type = 'button';
+    downloadNowButton.className = 'primary-btn';
+    downloadNowButton.textContent = ytDlpState.mode === 'subtitles' ? 'Download subtitles' : 'Download selection';
+    downloadNowButton.addEventListener('click', () => {
+        if (ytDlpState.mode === 'subtitles') {
+            handleYtDlpDownload(null);
+        } else if (ytDlpState.selectedFormatId) {
+            handleYtDlpDownload(ytDlpState.selectedFormatId);
+        } else {
+            openYtDlpModal();
+        }
+    });
+    actions.appendChild(downloadNowButton);
+    ytDlpState.dom.downloadActionButton = downloadNowButton;
 
     if (subtitleLanguages.length > 1) {
         const subtitleFilter = createSubtitleFilterControl(subtitleLanguages, ytDlpState.subtitleLanguageFilter);
@@ -1509,17 +1664,11 @@ function renderYtDlpResults(args = {}) {
 
     const helper = document.createElement('p');
     helper.className = 'helper-text';
-    helper.textContent = hasFormats
-        ? 'Pick a quality to download or try a different recipe from the dropdown above.'
-        : 'No downloadable formats were reported, but raw metadata is available below.';
+    helper.textContent =
+        ytDlpState.mode === 'subtitles'
+            ? 'Use the subtitle controls in the form to choose a source and languages before downloading.'
+            : 'Pick a quality to download or customise the advanced options below.';
     actions.appendChild(helper);
-
-    if (raw && raw.shortcuts) {
-        const shortcuts = createShortcutLinks(raw.shortcuts);
-        if (shortcuts) {
-            actions.appendChild(shortcuts);
-        }
-    }
 
     summaryNodes.push(actions);
 
@@ -1551,14 +1700,58 @@ function renderYtDlpResults(args = {}) {
     }
 
     setResult('media-results', groups);
-    setDownloadButtonsState(hasFormats);
+    const hasRelevantFormats = ytDlpState.mode === 'subtitles' ? true : hasFormatsForCurrentMode();
+    setDownloadButtonsState(hasRelevantFormats);
 }
 
 function setDownloadButtonsState(enabled) {
     const dom = ytDlpState.dom || {};
+    const mode = ytDlpState.mode || 'video';
     if (dom.openModalButton) {
-        dom.openModalButton.disabled = !enabled;
+        dom.openModalButton.disabled = mode === 'subtitles' ? true : !enabled;
     }
+    if (dom.downloadActionButton) {
+        if (mode === 'subtitles') {
+            dom.downloadActionButton.disabled = false;
+            dom.downloadActionButton.textContent = 'Download subtitles';
+        } else {
+            dom.downloadActionButton.disabled = !enabled;
+            dom.downloadActionButton.textContent = 'Download selection';
+        }
+    }
+}
+
+function selectBestThumbnail(metadata) {
+    if (!metadata || typeof metadata !== 'object') {
+        return null;
+    }
+
+    if (metadata.thumbnail && typeof metadata.thumbnail === 'string') {
+        return metadata.thumbnail;
+    }
+
+    if (!Array.isArray(metadata.thumbnails)) {
+        return null;
+    }
+
+    const sorted = metadata.thumbnails
+        .filter((entry) => entry && typeof entry.url === 'string')
+        .map((entry) => ({
+            url: entry.url,
+            width: Number(entry.width) || 0,
+            height: Number(entry.height) || 0,
+        }))
+        .filter((entry) => entry.url.length)
+        .sort((a, b) => {
+            const aScore = (a.width || 0) * (a.height || 0);
+            const bScore = (b.width || 0) * (b.height || 0);
+            if (aScore === bScore) {
+                return (b.width || 0) - (a.width || 0);
+            }
+            return bScore - aScore;
+        });
+
+    return sorted.length ? sorted[0].url : null;
 }
 
 function buildYtDlpDownloadNodes(download) {
@@ -1573,8 +1766,14 @@ function buildYtDlpDownloadNodes(download) {
     const nodes = [];
 
     if (download.blob) {
-        const label = download.blobLabel || 'Download media';
-        nodes.push(createDownloadLinkFromBlob(download.blob, download.filename, label));
+        const preview = createMediaPreviewFromBlob(download.blob, download.contentType, download.filename);
+        if (preview) {
+            nodes.push(preview);
+        }
+        const blobLink = createDownloadLinkFromBlob(download.blob, download.filename, 'Download file');
+        if (blobLink) {
+            nodes.push(blobLink);
+        }
     }
 
     if (download.directUrl) {
@@ -1585,6 +1784,20 @@ function buildYtDlpDownloadNodes(download) {
         }
     }
 
+    if (download.filename) {
+        const summary = document.createElement('p');
+        summary.className = 'helper-text';
+        summary.textContent = `Stored as ${download.filename}`;
+        nodes.push(summary);
+    }
+
+    if (download.previewError) {
+        const warning = document.createElement('p');
+        warning.className = 'helper-text is-error';
+        warning.textContent = download.previewError;
+        nodes.push(warning);
+    }
+
     if (download.meta && typeof download.meta === 'object' && !Array.isArray(download.meta)) {
         const entries = Object.keys(download.meta);
         if (entries.length) {
@@ -1593,6 +1806,43 @@ function buildYtDlpDownloadNodes(download) {
     }
 
     return nodes;
+}
+
+function createMediaPreviewFromBlob(blob, contentType, filename) {
+    if (!blob) {
+        return null;
+    }
+
+    const mimeType = (contentType || blob.type || '').toLowerCase();
+    const isVideo = mimeType.startsWith('video/');
+    const isAudio = mimeType.startsWith('audio/');
+
+    if (!isVideo && !isAudio) {
+        return null;
+    }
+
+    const url = URL.createObjectURL(blob);
+    const wrapper = document.createElement('div');
+    wrapper.className = 'media-preview';
+    wrapper.dataset.objectUrl = url;
+
+    const mediaElement = document.createElement(isVideo ? 'video' : 'audio');
+    mediaElement.controls = true;
+    mediaElement.preload = 'metadata';
+    mediaElement.src = url;
+    mediaElement.className = isVideo ? 'media-preview__video' : 'media-preview__audio';
+    mediaElement.title = filename ? `Preview: ${filename}` : 'Media preview';
+
+    wrapper.appendChild(mediaElement);
+
+    const helper = document.createElement('p');
+    helper.className = 'helper-text';
+    helper.textContent = isVideo
+        ? 'Preview the downloaded video without leaving the page.'
+        : 'Preview the downloaded audio without leaving the page.';
+    wrapper.appendChild(helper);
+
+    return wrapper;
 }
 
 function openYtDlpModal() {
@@ -1655,7 +1905,19 @@ function populateYtDlpModal(formats) {
     }
 
     qualityList.innerHTML = '';
-    const options = normaliseYtDlpFormats(formats);
+    if (ytDlpState.mode === 'subtitles') {
+        ytDlpState.formatsById = new Map();
+        const message = document.createElement('p');
+        message.className = 'helper-text';
+        message.textContent = 'Subtitles will be collected using the language and source settings from the form.';
+        qualityList.appendChild(message);
+        if (downloadButton) {
+            downloadButton.disabled = false;
+        }
+        return;
+    }
+
+    const options = normaliseYtDlpFormats(formats, ytDlpState.mode);
     ytDlpState.formatsById = new Map(options.map((option) => [option.id, option.original]));
 
     if (!options.length) {
@@ -1711,7 +1973,7 @@ function populateYtDlpModal(formats) {
     }
 }
 
-function normaliseYtDlpFormats(formats) {
+function normaliseYtDlpFormats(formats, mode = 'video') {
     if (!Array.isArray(formats)) {
         return [];
     }
@@ -1725,7 +1987,15 @@ function normaliseYtDlpFormats(formats) {
         if (!format.format_id || seen.has(format.format_id)) {
             return false;
         }
-        if (!isVideoFormat(format) && !isAudioFormat(format)) {
+        const video = isVideoFormat(format);
+        const audio = isAudioFormat(format);
+        if (!video && !audio) {
+            return false;
+        }
+        if (mode === 'video' && !video) {
+            return false;
+        }
+        if (mode === 'audio' && !audio) {
             return false;
         }
         seen.add(format.format_id);
@@ -1735,7 +2005,7 @@ function normaliseYtDlpFormats(formats) {
     filtered.sort((a, b) => {
         const aVideo = isVideoFormat(a);
         const bVideo = isVideoFormat(b);
-        if (aVideo !== bVideo) {
+        if (aVideo !== bVideo && mode !== 'audio') {
             return aVideo ? -1 : 1;
         }
 
@@ -1803,15 +2073,30 @@ function updateYtDlpQualitySelection(formatId) {
 
     downloadButton.disabled = false;
     downloadButton.textContent = buildYtDlpDownloadLabel(ytDlpState.formatsById.get(formatId));
+    setDownloadButtonsState(hasFormatsForCurrentMode());
 }
 
 async function handleYtDlpDownload(formatId) {
     const dom = ytDlpState.dom || {};
-    const downloadButton = dom.modalDownloadButton;
-    if (!formatId) {
-        return;
+    const mode = ytDlpState.mode || 'video';
+    let effectiveFormatId = formatId;
+
+    if (mode !== 'subtitles') {
+        if (!effectiveFormatId) {
+            effectiveFormatId = ytDlpState.selectedFormatId || null;
+        }
+        if (!effectiveFormatId) {
+            showToast('Pick a quality before downloading.', 'error');
+            return;
+        }
+        if (!ytDlpState.formatsById.has(effectiveFormatId)) {
+            showToast('Select a valid format to download.', 'error');
+            return;
+        }
+        ytDlpState.selectedFormatId = effectiveFormatId;
     }
 
+    const downloadButton = dom.modalDownloadButton;
     const originalLabel = downloadButton ? downloadButton.textContent : null;
     if (downloadButton) {
         downloadButton.disabled = true;
@@ -1819,76 +2104,172 @@ async function handleYtDlpDownload(formatId) {
     }
 
     try {
-        if (!ytDlpState.formatsById.has(formatId)) {
-            throw new Error('Select a valid format to download.');
-        }
-        const payload = buildYtDlpPayload('binary', { formatOverride: formatId });
+        const payload = buildYtDlpPayload('download', { formatOverride: effectiveFormatId });
         const jobId = generateYtDlpJobId();
         payload.job_id = jobId;
         startYtDlpDownloadProgress();
         openYtDlpProgressStream(jobId);
-        const { blob, response } = await fetchBinaryWithProgress(
-            '/media/yt-dlp',
-            {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(payload)
+
+        const response = await fetch('/media/yt-dlp', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
             },
-            (loaded, total) => updateYtDlpDownloadProgress(loaded, total, { stage: 'downloading' })
-        );
-        completeYtDlpDownloadProgress('Download ready');
-        closeYtDlpProgressStream();
-        const selectedFormat = ytDlpState.formatsById.get(formatId) || null;
-        const filename =
-            payload.filename ||
-            parseFilename(response.headers.get('Content-Disposition')) ||
-            buildFilenameFromMetadata(ytDlpState.metadata, selectedFormat);
+            body: JSON.stringify(payload)
+        });
 
-        const directUrl = buildDirectDownloadUrl({ url: payload.url, format: formatId, filename });
-        const downloadState = {
-            blob,
-            filename,
-            blobLabel: 'Download media',
-            directUrl,
-            directLabel: 'Open API download link'
-        };
+        const result = await parseResponse(response);
 
-        if (selectedFormat) {
-            const downloadMeta = {};
-            downloadMeta['Format ID'] = selectedFormat.format_id;
-            if (selectedFormat.ext) {
-                downloadMeta.Container = `.${selectedFormat.ext}`;
-            }
-            const qualityLabel = buildYtDlpFormatLabel(selectedFormat);
-            if (qualityLabel) {
-                downloadMeta.Quality = qualityLabel;
-            }
-            const reportedSize = selectedFormat.filesize || selectedFormat.filesize_approx;
-            if (reportedSize) {
-                downloadMeta['Reported size'] = formatBytes(reportedSize) || `${reportedSize} bytes`;
-            }
-            downloadState.meta = downloadMeta;
+        if (!result || !result.download) {
+            throw new Error('yt-dlp did not return a stored download.');
         }
+
+        ytDlpState.metadata = result.metadata || ytDlpState.metadata;
+        ytDlpState.rawResponse = result;
+
+        const downloadInfo = result.download;
+        const downloadState = await hydrateStoredDownload(downloadInfo);
 
         closeYtDlpModal();
         renderYtDlpResults({ metadata: ytDlpState.metadata, raw: ytDlpState.rawResponse, download: downloadState });
-        showToast('Media download ready.');
+
+        if (downloadState && downloadState.previewError) {
+            completeYtDlpDownloadProgress('Download ready (preview unavailable)');
+            showToast(downloadState.previewError, 'warning');
+        } else {
+            completeYtDlpDownloadProgress('Download ready');
+            showToast('Media download ready.');
+        }
     } catch (error) {
         console.error(error);
         failYtDlpDownloadProgress(error.message || 'Download failed');
         closeYtDlpProgressStream();
         showToast(error.message || 'Download failed', 'error');
-        return;
     } finally {
         closeYtDlpProgressStream();
         if (downloadButton) {
-            const fallback = downloadButton.dataset.originalLabel || originalLabel || 'Download selection';
+            const fallback =
+                downloadButton.dataset.originalLabel ||
+                originalLabel ||
+                (mode === 'subtitles' ? 'Download subtitles' : 'Download selection');
             downloadButton.textContent = fallback;
             downloadButton.disabled = false;
         }
     }
+}
+
+function buildStoredDownloadState(descriptor) {
+    if (!descriptor || typeof descriptor !== 'object') {
+        return null;
+    }
+
+    let meta = {};
+    if (descriptor.id) {
+        meta['Stored file ID'] = descriptor.id;
+    }
+
+    if (descriptor.content_type) {
+        meta['Content type'] = descriptor.content_type;
+    }
+
+    const rawSize = Number(descriptor.filesize);
+    if (Number.isFinite(rawSize) && rawSize >= 0) {
+        meta['File size'] = formatBytes(rawSize) || `${rawSize} bytes`;
+    } else if (descriptor.filesize) {
+        meta['File size'] = String(descriptor.filesize);
+    }
+
+    if (descriptor.metadata && typeof descriptor.metadata === 'object') {
+        meta = {
+            ...meta,
+            ...normaliseDownloadMetadata(descriptor.metadata)
+        };
+    }
+
+    return {
+        directUrl: descriptor.url || '',
+        directLabel: 'Open download link',
+        filename: descriptor.filename || 'download',
+        contentType: descriptor.content_type || '',
+        meta
+    };
+}
+
+async function hydrateStoredDownload(descriptor) {
+    const state = buildStoredDownloadState(descriptor);
+    if (!state) {
+        return null;
+    }
+
+    if (!descriptor.url) {
+        return state;
+    }
+
+    const rawSize = Number(descriptor.filesize);
+    const previewTooLarge = Number.isFinite(rawSize) && rawSize > YT_DLP_PREVIEW_SIZE_LIMIT;
+
+    if (previewTooLarge) {
+        const limitLabel = formatBytes(YT_DLP_PREVIEW_SIZE_LIMIT) || '75 MB';
+        state.previewError = `Preview unavailable for large files (> ${limitLabel}). Use the download link instead.`;
+        return state;
+    }
+
+    try {
+        updateYtDlpDownloadProgress(undefined, undefined, {
+            stage: 'fetching',
+            message: 'Fetching stored media…'
+        });
+
+        const { blob, response } = await fetchBinaryWithProgress(
+            descriptor.url,
+            { method: 'GET' },
+            (loaded, total) =>
+                updateYtDlpDownloadProgress(loaded, total, {
+                    stage: 'fetching',
+                    message: 'Fetching stored media…'
+                })
+        );
+
+        const contentType =
+            response.headers.get('Content-Type') ||
+            descriptor.content_type ||
+            blob.type ||
+            'application/octet-stream';
+        const disposition = response.headers.get('Content-Disposition');
+        const inferredFilename = parseFilename(disposition);
+
+        state.blob = blob;
+        state.contentType = contentType;
+        state.filename = inferredFilename || state.filename;
+
+        if (contentType) {
+            state.meta['Content type'] = contentType;
+        }
+
+        const size = blob.size;
+        if (Number.isFinite(size) && size >= 0) {
+            state.meta['File size'] = formatBytes(size) || `${size} bytes`;
+        }
+
+        const metadataHeader = response.headers.get('X-YtDlp-Metadata');
+        if (metadataHeader) {
+            try {
+                const decoded = JSON.parse(atob(metadataHeader));
+                state.meta = {
+                    ...state.meta,
+                    ...normaliseDownloadMetadata(decoded)
+                };
+            } catch (error) {
+                console.warn('Failed to parse stored metadata header', error);
+            }
+        }
+    } catch (error) {
+        console.warn('Unable to fetch stored download', error);
+        const message = error instanceof Error ? error.message : 'Unable to fetch stored media.';
+        state.previewError = `Preview unavailable: ${message}`;
+    }
+
+    return state;
 }
 
 function buildYtDlpFormatLabel(format) {
@@ -2180,10 +2561,33 @@ async function parseBinaryResponse(response) {
 }
 
 async function fetchBinaryWithProgress(url, options, onProgress) {
-    const response = await fetch(url, options);
+    let response;
+    try {
+        response = await fetch(url, options);
+    } catch (error) {
+        throw new Error('Network error while fetching media. Please try again.');
+    }
+
     if (!response.ok) {
-        const text = await response.text();
-        throw new Error(text || `Request failed (${response.status})`);
+        let message = '';
+        const contentType = response.headers.get('Content-Type') || '';
+        if (contentType.includes('application/json')) {
+            try {
+                const payload = await response.clone().json();
+                if (payload && typeof payload.detail === 'string') {
+                    message = payload.detail;
+                }
+            } catch (error) {
+                // fall through to text handling
+            }
+        }
+
+        if (!message) {
+            const text = await response.text();
+            message = text && text.trim() ? text : `Request failed (${response.status})`;
+        }
+
+        throw new Error(message);
     }
 
     const contentType = response.headers.get('Content-Type') || 'application/octet-stream';
@@ -2318,6 +2722,8 @@ function ytDlpStageMessage(stage) {
             return 'Downloading media…';
         case 'packaging':
             return 'Packaging download…';
+        case 'fetching':
+            return 'Fetching stored media…';
         case 'finished':
             return 'Wrapping up download…';
         default:
@@ -2845,55 +3251,6 @@ function createSubtitleList(entries, languageFilter) {
     return wrapper;
 }
 
-function createShortcutLinks(shortcuts) {
-    const entries = Object.entries(shortcuts || {}).filter(([, href]) => typeof href === 'string' && href.length);
-    if (!entries.length) {
-        return null;
-    }
-
-    const wrapper = document.createElement('div');
-    wrapper.className = 'yt-dlp-shortcuts';
-
-    const label = document.createElement('span');
-    label.textContent = 'Quick API links';
-    wrapper.appendChild(label);
-
-    entries.forEach(([key, href]) => {
-        const link = document.createElement('a');
-        link.href = toAbsoluteUrl(href);
-        link.target = '_blank';
-        link.rel = 'noreferrer';
-        const label = YT_DLP_SHORTCUT_LABELS[key] || key;
-        link.textContent = label;
-        link.title = `Download using the ${label.toLowerCase()} preset`;
-        wrapper.appendChild(link);
-    });
-
-    return wrapper;
-}
-
-function toAbsoluteUrl(href) {
-    if (!href) {
-        return '';
-    }
-    try {
-        return new URL(href, window.location.origin).toString();
-    } catch (error) {
-        return href;
-    }
-}
-
-function buildDirectDownloadUrl({ url, format, filename }) {
-    if (!url || !format) {
-        return null;
-    }
-    const params = new URLSearchParams({ url, format });
-    if (filename) {
-        params.set('filename', filename);
-    }
-    return `/media/yt-dlp/direct?${params.toString()}`;
-}
-
 function formatBytes(bytes) {
     const value = Number(bytes);
     if (!Number.isFinite(value) || value <= 0) {
@@ -3004,8 +3361,14 @@ function createDownloadLinkFromUrl(href, label = 'Open download link') {
     if (!href) {
         return null;
     }
+    let resolvedHref = href;
+    try {
+        resolvedHref = new URL(href, window.location.origin).toString();
+    } catch (error) {
+        console.warn('Failed to normalise download URL', error);
+    }
     const link = document.createElement('a');
-    link.href = toAbsoluteUrl(href);
+    link.href = resolvedHref;
     link.target = '_blank';
     link.rel = 'noreferrer';
     link.className = 'download-link is-outline';

--- a/tools-api/app/templates/studio.html
+++ b/tools-api/app/templates/studio.html
@@ -488,20 +488,44 @@
                         <form id="yt-dlp-form" class="tool-form">
                             <div class="form-header">
                                 <h3>yt-dlp Inspector</h3>
-                                <p class="muted">Preview the media details, then pick a ready-made download recipe.</p>
+                                <p class="muted">Preview the media details, then decide if you want video, audio, or subtitles.</p>
                             </div>
                             <label for="yt-dlp-url">URL</label>
                             <input id="yt-dlp-url" type="url" required placeholder="https://www.youtube.com/watch?v=..." />
 
-                            <label for="yt-dlp-template">Quick recipe</label>
-                            <select id="yt-dlp-template">
-                                <option value="best">Best quality video</option>
-                                <option value="hd1080">HD 1080p (if available)</option>
-                                <option value="audio">Audio only</option>
-                                <option value="subtitles">Grab subtitles</option>
-                                <option value="custom">Custom setup</option>
-                            </select>
-                            <p id="yt-dlp-template-hint" class="helper-text"></p>
+                            <div class="field-group">
+                                <span class="field-label">Download type</span>
+                                <div id="yt-dlp-mode-toggle" class="pill-toggle">
+                                    <label class="pill-option">
+                                        <input type="radio" name="yt-dlp-mode" value="video" checked />
+                                        <span>Video</span>
+                                    </label>
+                                    <label class="pill-option">
+                                        <input type="radio" name="yt-dlp-mode" value="audio" />
+                                        <span>Audio</span>
+                                    </label>
+                                    <label class="pill-option">
+                                        <input type="radio" name="yt-dlp-mode" value="subtitles" />
+                                        <span>Subtitles</span>
+                                    </label>
+                                </div>
+                                <p class="helper-text">Switch modes before downloading to tailor the controls below.</p>
+                            </div>
+                            <div id="yt-dlp-subtitle-controls" class="subtitle-controls" hidden>
+                                <div class="field-row">
+                                    <label class="radio">
+                                        <input type="radio" name="yt-dlp-subtitle-source" value="original" checked />
+                                        <span>Original subtitles</span>
+                                    </label>
+                                    <label class="radio">
+                                        <input type="radio" name="yt-dlp-subtitle-source" value="auto" />
+                                        <span>Auto translated</span>
+                                    </label>
+                                </div>
+                                <label for="yt-dlp-subtitle-language-list">Languages</label>
+                                <select id="yt-dlp-subtitle-language-list" multiple size="6"></select>
+                                <p class="helper-text">Pick one or more subtitle tracks. Leave empty to use the first available option.</p>
+                            </div>
 
                             <div class="form-actions">
                                 <button type="submit" class="primary-btn">Preview media info</button>

--- a/tools-api/tests/test_media.py
+++ b/tools-api/tests/test_media.py
@@ -1,12 +1,17 @@
 import base64
+import io
 import json
+import zipfile
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 
 import app.routers.media as media_router
 from app.main import app
-from app.services.yt_dlp_service import DownloadResult
+from app.services.download_store import DownloadStore
+import app.services.yt_dlp_service as yt_dlp_module
+from app.services.yt_dlp_service import DownloadResult, YtDlpService
 
 
 @pytest.fixture
@@ -14,12 +19,20 @@ def client():
     return TestClient(app)
 
 
+@pytest.fixture
+def temp_download_store(monkeypatch, tmp_path):
+    store = DownloadStore(root=tmp_path)
+    monkeypatch.setattr(media_router, "download_store", store)
+    return store
+
+
 def test_yt_dlp_metadata_endpoint(client, monkeypatch):
     sample_metadata = {
         "id": "demo",
         "title": "Sample",
         "duration": 10,
-        "requested_subtitles": {"en": {"ext": "vtt", "url": "https://example.com/subs.vtt"}},
+        "subtitles": {"en": [{"ext": "vtt", "url": "https://example.com/subs.vtt"}]},
+        "automatic_captions": {"es": [{"ext": "vtt", "url": "https://example.com/auto.vtt"}]},
     }
 
     def fake_extract(url: str, *, options):
@@ -55,9 +68,11 @@ def test_yt_dlp_metadata_endpoint(client, monkeypatch):
     assert response.status_code == 200
     payload = response.json()
     assert payload["metadata"] == sample_metadata
+    assert payload["available_subtitles"]["original"] == ["en"]
+    assert payload["available_subtitles"]["auto"] == ["es"]
 
 
-def test_yt_dlp_binary_endpoint(client, monkeypatch):
+def test_yt_dlp_download_endpoint(client, monkeypatch, temp_download_store):
     metadata = {"id": "demo", "title": "Sample", "ext": "mp4"}
 
     def fake_download(url: str, *, options, filename_override=None):
@@ -75,17 +90,27 @@ def test_yt_dlp_binary_endpoint(client, monkeypatch):
         "/media/yt-dlp",
         json={
             "url": "https://example.com/video",
-            "response_format": "binary",
+            "response_format": "download",
+            "mode": "video",
             "filename": "custom.mp4",
         },
     )
 
     assert response.status_code == 200
-    assert response.content == b"video-bytes"
-    assert response.headers["content-type"] == "video/mp4"
-    assert response.headers["Content-Disposition"].endswith("custom.mp4")
+    payload = response.json()
+    assert payload["metadata"]["title"] == "Sample"
+    download = payload["download"]
+    assert download["filename"] == "custom.mp4"
+    file_id = download["id"]
+    stored_file = temp_download_store.root / file_id / "custom.mp4"
+    assert stored_file.exists()
+    assert stored_file.read_bytes() == b"video-bytes"
 
-    metadata_header = response.headers.get("X-YtDlp-Metadata")
+    file_response = client.get(f"/media/yt-dlp/files/{file_id}")
+    assert file_response.status_code == 200
+    assert file_response.content == b"video-bytes"
+    assert file_response.headers["content-type"] == "video/mp4"
+    metadata_header = file_response.headers.get("X-YtDlp-Metadata")
     assert metadata_header is not None
     decoded = json.loads(base64.b64decode(metadata_header))
     assert decoded["title"] == "Sample"
@@ -104,4 +129,160 @@ def test_yt_dlp_failure_returns_error(client, monkeypatch):
 
     assert response.status_code == 502
     assert response.json()["detail"] == "boom"
+
+
+def test_yt_dlp_accepts_urls_without_scheme(client, monkeypatch):
+    captured: dict[str, str] = {}
+
+    def fake_extract(url: str, *, options):
+        captured["url"] = url
+        return {"id": "demo"}
+
+    monkeypatch.setattr(media_router.yt_dlp_service, "extract_info", fake_extract)
+
+    response = client.post(
+        "/media/yt-dlp",
+        json={"url": "youtube.com/watch?v=123"},
+    )
+
+    assert response.status_code == 200
+    assert captured["url"] == "https://youtube.com/watch?v=123"
+
+
+def test_yt_dlp_sanitises_filename_override(client, monkeypatch, temp_download_store):
+    captured: dict[str, str | None] = {}
+
+    def fake_download(url: str, *, options, filename_override=None):
+        captured["filename"] = filename_override
+        return DownloadResult(
+            content=b"bytes",
+            filename="video.mp4",
+            content_type="video/mp4",
+            metadata={"id": "demo"},
+        )
+
+    monkeypatch.setattr(media_router.yt_dlp_service, "download", fake_download)
+
+    response = client.post(
+        "/media/yt-dlp",
+        json={
+            "url": "https://example.com/video",
+            "response_format": "download",
+            "mode": "video",
+            "filename": "../custom/video.mp4",
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["filename"] == "video.mp4"
+
+
+def test_yt_dlp_subtitle_download(client, monkeypatch, temp_download_store):
+    metadata = {"id": "demo", "title": "Sample"}
+
+    def fake_download_subtitles(url: str, *, options, filename_override=None):
+        assert options["subtitleslangs"] == ["en"]
+        assert options["writeautomaticsub"] is True
+        return DownloadResult(
+            content=b"subtitle-bytes",
+            filename=filename_override or "sample.vtt",
+            content_type="text/vtt",
+            metadata=metadata,
+        )
+
+    monkeypatch.setattr(media_router.yt_dlp_service, "download_subtitles", fake_download_subtitles)
+
+    response = client.post(
+        "/media/yt-dlp",
+        json={
+            "url": "https://example.com/video",
+            "response_format": "download",
+            "mode": "subtitles",
+            "subtitle_languages": ["en"],
+            "subtitle_source": "auto",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["metadata"]["mode"] == "subtitles"
+    download = payload["download"]
+    assert download["filename"].endswith(".vtt")
+    file_id = download["id"]
+    stored_file = next((temp_download_store.root / file_id).glob("*.vtt"))
+    assert stored_file.read_bytes() == b"subtitle-bytes"
+
+
+def test_yt_dlp_subtitle_languages_accepts_string(client, monkeypatch):
+    captured_options: dict[str, object] = {}
+
+    def fake_extract(url: str, *, options):
+        captured_options.update(options)
+        return {"id": "demo"}
+
+    monkeypatch.setattr(media_router.yt_dlp_service, "extract_info", fake_extract)
+
+    response = client.post(
+        "/media/yt-dlp",
+        json={
+            "url": "https://example.com/video",
+            "options": {
+                "subtitleslangs": "en, es ,",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured_options["subtitleslangs"] == ["en", "es"]
+
+
+def test_download_subtitles_packages_multiple_languages(monkeypatch):
+    captured_options: dict[str, object] = {}
+
+    class FakeYoutubeDL:
+        def __init__(self, options):
+            self.options = options
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def extract_info(self, url, download):
+            assert url == "https://example.com/video"
+            assert download is True
+            captured_options.update(self.options)
+            outtmpl = self.options.get("outtmpl")
+            assert outtmpl is not None
+            out_path = Path(outtmpl)
+            directory = out_path.parent
+            directory.mkdir(parents=True, exist_ok=True)
+            (directory / "video.en.vtt").write_text("English", encoding="utf-8")
+            (directory / "video.fr.srt").write_text("Français", encoding="utf-8")
+            return {"id": "demo", "title": "Sample"}
+
+    class FakeYtDlpModule:
+        YoutubeDL = FakeYoutubeDL
+
+    monkeypatch.setattr(yt_dlp_module, "_ensure_yt_dlp", lambda: FakeYtDlpModule())
+
+    service = YtDlpService()
+    result = service.download_subtitles(
+        "https://example.com/video",
+        options={"writesubtitles": True, "subtitleslangs": ["en", "fr"]},
+    )
+
+    assert captured_options["writesubtitles"] is True
+    assert captured_options["skip_download"] is True
+    assert captured_options["subtitleslangs"] == ["en", "fr"]
+    assert result.content_type == "application/zip"
+    assert result.filename == "subtitles.zip"
+    assert sorted(result.metadata["subtitle_files"]) == ["video.en.vtt", "video.fr.srt"]
+
+    with zipfile.ZipFile(io.BytesIO(result.content)) as archive:
+        assert sorted(archive.namelist()) == ["video.en.vtt", "video.fr.srt"]
+        assert archive.read("video.en.vtt") == b"English"
+        assert archive.read("video.fr.srt") == "Français".encode("utf-8")
+
 


### PR DESCRIPTION
## Summary
- add a hydration helper for stored yt-dlp downloads that fetches binaries, merges metadata, and updates progress stages
- render inline previews with direct download links while surfacing warnings when previews are unavailable or skipped
- style helper text error states so preview warnings are visually distinct in the Studio UI

## Testing
- pytest tools-api/tests/test_media.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e19c5da83c8328866632258257ddc8