### PR TITLE
Fix Studio API base path handling and refresh docs

### DIFF
--- a/tools-api/app/runtime/documentation.py
+++ b/tools-api/app/runtime/documentation.py
@@ -108,11 +108,18 @@ def _catalog_services() -> Tuple[List[Dict[str, Any]], Optional[str]]:
     for service in services_raw:
         if not isinstance(service, dict):
             continue
+        flow = service.get("flow")
+        if isinstance(flow, list):
+            flow_steps = [str(step).strip() for step in flow if str(step).strip()]
+        else:
+            flow_steps = []
+
         entry = {
             "name": service.get("name", "Unnamed Service"),
             "summary": service.get("summary"),
             "docs_url": service.get("docs_url"),
             "endpoints": [],
+            "flow": flow_steps,
         }
         endpoints = service.get("endpoints", [])
         if isinstance(endpoints, list):
@@ -159,6 +166,12 @@ def _documentation_lines() -> Iterable[str]:
         docs_url = service.get("docs_url")
         if docs_url:
             yield f"   Interactive docs: {docs_url}"
+
+        flow_steps: List[str] = service.get("flow", []) if isinstance(service.get("flow"), list) else []
+        if flow_steps:
+            yield "   Workflow:"
+            for step in flow_steps:
+                yield f"     - {step}"
 
         endpoints: List[Dict[str, Any]] = service.get("endpoints", [])
         if endpoints:
@@ -251,6 +264,12 @@ def render_request_overview(host: str, port: int) -> str:
         summary = service.get("summary")
         if summary:
             lines.append(f"  {summary}")
+
+        flow_steps = service.get("flow") if isinstance(service.get("flow"), list) else []
+        if flow_steps:
+            lines.append("  Workflow:")
+            for step in flow_steps:
+                lines.append(f"    - {step}")
 
         for endpoint in service.get("endpoints", []):
             descriptor = f"  • {endpoint['headline']} — {endpoint['method']} {endpoint['path']}"

--- a/tools-api/docs/service_catalog.yaml
+++ b/tools-api/docs/service_catalog.yaml
@@ -164,78 +164,88 @@
               "error": "string – Present when status=failed."
             }
           }
-    }
-  ]
-},
-{
-  "name": "Image Effects",
-  "summary": "Expose the Before & After swipe generator and Halations glow filter via REST APIs.",
-  "docs_url": "http://localhost:8000/docs#/image-tools",
-  "endpoints": [
-    {
-      "method": "POST",
-      "path": "/image-tools/before-after",
-      "headline": "Before ↔ After Animation",
-      "tagline": "Create looping swipe videos from two images – straight from your automations.",
-      "description": "Uploads two images and returns a base64 MP4 (or binary stream) with a sliding divider that mimics the FUT-Coding before-and-after tool.",
-      "request": {
-        "content_type": "multipart/form-data",
-        "fields": {
-          "before_image": "file – Image showing the 'before' state.",
-          "after_image": "file – Image showing the 'after' state.",
-          "frame_width": "int (optional) – Override output width.",
-          "frame_height": "int (optional) – Override output height.",
-          "duration_seconds": "float (optional) – Clip duration (default 6s).",
-          "fps": "int (optional) – Frame rate (default 30).",
-          "cycles": "int (optional) – Number of divider passes (default 2).",
-          "line_thickness": "int (optional) – Divider thickness (default 6px).",
-          "add_text": "bool (optional) – Enable overlay text.",
-          "overlay_text": "string (optional) – Text content rendered when add_text is true.",
-          "response_format": "query: json|binary – Choose JSON (base64) or MP4 stream."
-        },
-        "notes": [
-          "When no optional parameters are supplied the API responds with a hint explaining customisation options."
-        ]
-      },
-      "response": {
-        "content_type": "application/json",
-        "fields": {
-          "video_base64": "string – Base64 encoded MP4 clip.",
-          "metadata": "object – Echoes dimensions, fps, duration, etc.",
-          "message": "string – Optional hint about available parameters."
         }
-      }
+      ],
+      "flow": [
+        "Call POST /parse/html or /parse/markdown to convert authoring content into Google Docs requests immediately.",
+        "For instant Docs payloads skip the queue with POST /parse/docs/(html|markdown); enqueue large jobs via /parse/queue/* and poll /parse/job/{job_id}.",
+        "Forward the returned requests array to the Google Docs batchUpdate API to build or update a document."
+      ]
     },
     {
-      "method": "POST",
-      "path": "/image-tools/halations",
-      "headline": "Halations Glow",
-      "tagline": "Wrap the FUT-Coding halations image filter inside Tools API.",
-      "description": "Applies a brightness-driven glow effect inspired by the halations open-source project.",
-      "request": {
-        "content_type": "multipart/form-data",
-        "fields": {
-          "image": "file – Source image.",
-          "blur_amount": "float (optional) – Blur radius for the glow mask (default 10).",
-          "brightness_threshold": "int (optional) – Highlight threshold (default 200).",
-          "strength": "float (optional) – Intensity of the overlay (default 50).",
-          "response_format": "query: json|binary – Choose JSON (base64) or JPEG stream."
+      "name": "Image Effects",
+      "summary": "Expose the Before & After swipe generator and Halations glow filter via REST APIs.",
+      "docs_url": "http://localhost:8000/docs#/image-tools",
+      "endpoints": [
+        {
+          "method": "POST",
+          "path": "/image-tools/before-after",
+          "headline": "Before ↔ After Animation",
+          "tagline": "Create looping swipe videos from two images – straight from your automations.",
+          "description": "Uploads two images and returns a base64 MP4 (or binary stream) with a sliding divider that mimics the FUT-Coding before-and-after tool.",
+          "request": {
+            "content_type": "multipart/form-data",
+            "fields": {
+              "before_image": "file – Image showing the 'before' state.",
+              "after_image": "file – Image showing the 'after' state.",
+              "frame_width": "int (optional) – Override output width.",
+              "frame_height": "int (optional) – Override output height.",
+              "duration_seconds": "float (optional) – Clip duration (default 6s).",
+              "fps": "int (optional) – Frame rate (default 30).",
+              "cycles": "int (optional) – Number of divider passes (default 2).",
+              "line_thickness": "int (optional) – Divider thickness (default 6px).",
+              "add_text": "bool (optional) – Enable overlay text.",
+              "overlay_text": "string (optional) – Text content rendered when add_text is true.",
+              "response_format": "query: json|binary – Choose JSON (base64) or MP4 stream."
+            },
+            "notes": [
+              "When no optional parameters are supplied the API responds with a hint explaining customisation options."
+            ]
+          },
+          "response": {
+            "content_type": "application/json",
+            "fields": {
+              "video_base64": "string – Base64 encoded MP4 clip.",
+              "metadata": "object – Echoes dimensions, fps, duration, etc.",
+              "message": "string – Optional hint about available parameters."
+            }
+          }
         },
-        "notes": [
-          "Default requests include a hint about tweaking blur_amount, brightness_threshold, and strength."
-        ]
-      },
-      "response": {
-        "content_type": "application/json",
-        "fields": {
-          "image_base64": "string – Base64 encoded JPEG with glow applied.",
-          "metadata": "object – Echoes dimensions and parameter values.",
-          "message": "string – Optional hint about available parameters."
+        {
+          "method": "POST",
+          "path": "/image-tools/halations",
+          "headline": "Halations Glow",
+          "tagline": "Wrap the FUT-Coding halations image filter inside Tools API.",
+          "description": "Applies a brightness-driven glow effect inspired by the halations open-source project.",
+          "request": {
+            "content_type": "multipart/form-data",
+            "fields": {
+              "image": "file – Source image.",
+              "blur_amount": "float (optional) – Blur radius for the glow mask (default 10).",
+              "brightness_threshold": "int (optional) – Highlight threshold (default 200).",
+              "strength": "float (optional) – Intensity of the overlay (default 50).",
+              "response_format": "query: json|binary – Choose JSON (base64) or JPEG stream."
+            },
+            "notes": [
+              "Default requests include a hint about tweaking blur_amount, brightness_threshold, and strength."
+            ]
+          },
+          "response": {
+            "content_type": "application/json",
+            "fields": {
+              "image_base64": "string – Base64 encoded JPEG with glow applied.",
+              "metadata": "object – Echoes dimensions and parameter values.",
+              "message": "string – Optional hint about available parameters."
+            }
+          }
         }
-      }
-    }
-  ]
-},
+      ],
+      "flow": [
+        "POST /image-tools/halations or /image-tools/before-after with form-data uploads to generate visuals.",
+        "Set response_format=binary when you want the raw media stream; otherwise read the base64 payload from the JSON response.",
+        "Store or forward the metadata block to keep track of dimensions and render options."
+      ]
+    },
     {
       "name": "Google Docs JSON Parser",
       "summary": "Pull plain text, links, and image references out of Google Docs JSON exports for downstream automations.",
@@ -286,6 +296,10 @@
             }
           }
         }
+      ],
+      "flow": [
+        "Export a Google Doc as JSON and send it to POST /parse/gdocs/json (or upload with /parse/gdocs/file).",
+        "Use the plain text, URL list, and image references in automation steps or LLM prompts."
       ]
     },
     {
@@ -314,6 +328,10 @@
             }
           }
         }
+      ],
+      "flow": [
+        "Upload a .docx file directly to POST /docx/parse (set the Content-Type header that matches the file).",
+        "Use the returned text for AI prompts, search indexing, or to seed downstream document generators."
       ]
     },
     {
@@ -376,7 +394,37 @@
               "When requesting `response_format=binary`, Tools API returns the media bytes and a `X-Cobalt-Metadata` header containing the JSON payload (base64)."
             ]
           }
+        },
+        {
+          "method": "POST",
+          "path": "/js-tools/cobalt/shortcuts/{shortcut}",
+          "headline": "One-click Cobalt presets",
+          "tagline": "Trigger opinionated download presets (YouTube audio, metadata-only, etc.) without hand-crafting payloads.",
+          "description": "Applies a named preset from the shortcut registry and forwards the request to the configured Cobalt backend.",
+          "request": {
+            "content_type": "application/json",
+            "fields": {
+              "url": "string – Source URL.",
+              "response_format": "string – Optional. Use 'binary' to stream the media file instead of JSON.",
+              "extra_fields": "Any additional keys override the preset before reaching Cobalt."
+            }
+          },
+          "response": {
+            "content_type": "application/json | application/octet-stream",
+            "fields": {
+              "status": "string – Mirrors the Cobalt response status.",
+              "url": "string – Direct download URL when response_format=json."
+            },
+            "notes": [
+              "Binary responses include Content-Disposition and X-Cobalt-Metadata headers for automation platforms."
+            ]
+          }
         }
+      ],
+      "flow": [
+        "Install Node.js so Tools API can bootstrap the bundled utilities (panosplitter and Cobalt helpers).",
+        "POST /js-tools/panosplitter to split panoramas; request binary responses for ready-to-share zip archives.",
+        "Configure COBALT_API_BASE_URL then call /js-tools/cobalt or /js-tools/cobalt/shortcuts/{slug} to proxy downloads through your Cobalt instance."
       ]
     },
     {
@@ -396,7 +444,12 @@
               "url": "string – URL to inspect or download.",
               "response_format": "string – 'json' (default metadata) or 'binary' to stream the file.",
               "filename": "string – Optional filename override when streaming the binary response.",
-              "options": "object – Optional yt-dlp options such as format, playlist_items, proxy, or custom headers."
+              "options": "object – Optional yt-dlp options such as format, playlist_items, proxy, or custom headers.",
+              "mode": "string – 'video' (default), 'audio', or 'subtitles' to change the download behaviour.",
+              "job_id": "string – Optional. Provide a unique identifier to stream progress updates via SSE.",
+              "format_id": "string – Optional. Force a specific format reported by yt-dlp metadata.",
+              "subtitle_source": "string – Optional. 'original' or 'auto' when requesting subtitles.",
+              "subtitle_languages": "list|string – Languages to prioritise when subtitle workflows are enabled."
             }
           },
           "response": {
@@ -408,7 +461,44 @@
               "Binary responses include automation-friendly headers: Content-Disposition and X-YtDlp-Metadata (base64 JSON)."
             ]
           }
+        },
+        {
+          "method": "GET",
+          "path": "/media/yt-dlp/files/{file_id}",
+          "headline": "Fetch stored download",
+          "tagline": "Retrieve the binary asset saved during a yt-dlp download request.",
+          "description": "Streams a previously stored download by its identifier and echoes metadata headers.",
+          "response": {
+            "content_type": "application/octet-stream",
+            "fields": {
+              "body": "binary – Media file previously downloaded by yt-dlp."
+            },
+            "notes": [
+              "Responses include X-YtDlp-Metadata (base64 JSON) plus a Content-Disposition filename."
+            ]
+          }
+        },
+        {
+          "method": "GET",
+          "path": "/media/yt-dlp/progress/{job_id}",
+          "headline": "Live download progress",
+          "tagline": "Subscribe to Server-Sent Events that mirror yt-dlp progress callbacks.",
+          "description": "Streams JSON-formatted progress events when the POST /media/yt-dlp request supplies a job_id.",
+          "response": {
+            "content_type": "text/event-stream",
+            "fields": {
+              "event": "SSE stream – Progress, error, and completion messages encoded as JSON strings."
+            },
+            "notes": [
+              "Events publish stages such as starting, downloading, packaging, complete, or error."
+            ]
+          }
         }
+      ],
+      "flow": [
+        "POST /media/yt-dlp with response_format=json to inspect metadata or 'binary' to trigger a download (optionally provide job_id for live progress).",
+        "When using job_id, subscribe to GET /media/yt-dlp/progress/{job_id} for Server-Sent Events that track the download pipeline.",
+        "Read the download descriptor and fetch the stored file from GET /media/yt-dlp/files/{file_id}, or hand the metadata to your automation."
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- teach the Studio dashboard to resolve the API base path from the OpenAPI URL so every fetch respects reverse-proxy prefixes
- document end-to-end workflows for each service in `docs/service_catalog.yaml` and surface them in the runtime documentation helpers
- rewrite the README with step-by-step setup instructions, sample curl commands, and updated troubleshooting tips for non-developers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1fc099a1c8328b43c3677364a344b