### PR TITLE
Add FFmpeg conversion tooling and studio integration

### DIFF
--- a/tools-api/app/main.py
+++ b/tools-api/app/main.py
@@ -13,7 +13,7 @@ from fastapi.templating import Jinja2Templates
 
 from app.config import settings
 from app.extensions import local_queue_extension
-from app.routers import docx, gdocs_parser, image_tools, js_tools, media, parser
+from app.routers import docx, ffmpeg, gdocs_parser, image_tools, js_tools, media, parser
 from app.services.cobalt_gateway import CobaltError, create_gateway
 from app.services.cobalt_shortcuts import list_shortcuts
 from app.utils.logger import logger
@@ -147,6 +147,7 @@ async def log_requests(request: Request, call_next):
 # Routers
 app.include_router(parser.router, prefix="/parse", tags=["parser"])
 app.include_router(docx.router)  # Already has /docx prefix
+app.include_router(ffmpeg.router)
 app.include_router(gdocs_parser.router)
 app.include_router(js_tools.router)
 app.include_router(media.router)

--- a/tools-api/app/routers/__init__.py
+++ b/tools-api/app/routers/__init__.py
@@ -1,9 +1,10 @@
 """FastAPI router modules exposed by Tools API."""
 
-from . import docx, gdocs_parser, js_tools, media, parser  # noqa: F401
+from . import docx, ffmpeg, gdocs_parser, js_tools, media, parser  # noqa: F401
 
 __all__ = [
     "docx",
+    "ffmpeg",
     "gdocs_parser",
     "js_tools",
     "media",

--- a/tools-api/app/routers/ffmpeg.py
+++ b/tools-api/app/routers/ffmpeg.py
@@ -1,0 +1,60 @@
+"""FFmpeg powered media conversion endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi.concurrency import run_in_threadpool
+from fastapi.responses import FileResponse
+from pydantic import BaseModel, Field
+from starlette.background import BackgroundTask
+
+from app.services.ffmpeg_service import ConversionResult, FfmpegServiceError, ffmpeg_service
+
+router = APIRouter(prefix="/media/ffmpeg", tags=["ffmpeg"])
+
+
+class FormatListResponse(BaseModel):
+    inputs: list[str] = Field(default_factory=list, description="Formats FFmpeg can read.")
+    outputs: list[str] = Field(default_factory=list, description="Formats FFmpeg can write.")
+    common: list[str] = Field(default_factory=list, description="Formats available for both input and output.")
+
+
+@router.get("/formats", response_model=FormatListResponse)
+async def list_formats() -> FormatListResponse:
+    """Return cached FFmpeg format capabilities."""
+
+    try:
+        formats = await run_in_threadpool(ffmpeg_service.list_formats)
+    except FfmpegServiceError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    return FormatListResponse.model_validate(formats)
+
+
+@router.post("/convert")
+async def convert_media(
+    file: UploadFile = File(..., description="Media file to convert."),
+    target_format: str = Form(..., description="Desired output container/format."),
+    source_format: str | None = Form(None, description="Optional hint for the input container."),
+) -> FileResponse:
+    """Convert media using FFmpeg and stream back the resulting file."""
+
+    await file.seek(0)
+    try:
+        result: ConversionResult = await run_in_threadpool(
+            ffmpeg_service.convert_upload,
+            file,
+            source_format=source_format,
+            target_format=target_format,
+        )
+    except FfmpegServiceError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    finally:
+        await file.close()
+
+    background = BackgroundTask(ffmpeg_service.cleanup_directory, result.workdir)
+    return FileResponse(
+        path=result.output_path,
+        filename=result.filename,
+        media_type=result.media_type,
+        background=background,
+    )

--- a/tools-api/app/services/ffmpeg_service.py
+++ b/tools-api/app/services/ffmpeg_service.py
@@ -1,0 +1,210 @@
+"""Utilities for interacting with the system FFmpeg binary."""
+from __future__ import annotations
+
+import mimetypes
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Lock
+from typing import Iterable, Tuple
+
+from fastapi import UploadFile
+
+FORMAT_LINE_PATTERN = re.compile(r"^\s*([D\.])([E\.])\s+([^\s]+)")
+_CACHE_TTL_SECONDS = 60 * 60  # one hour
+
+
+class FfmpegServiceError(RuntimeError):
+    """Raised when FFmpeg operations fail or are unavailable."""
+
+
+@dataclass(frozen=True)
+class ConversionResult:
+    """Represents a successful FFmpeg conversion."""
+
+    output_path: Path
+    filename: str
+    media_type: str
+    workdir: Path
+
+
+class FfmpegService:
+    """Lightweight wrapper around the FFmpeg CLI for conversions."""
+
+    def __init__(self) -> None:
+        self._cache_lock = Lock()
+        self._cached_formats: Tuple[float, dict[str, list[str]]] | None = None
+
+    def list_formats(self) -> dict[str, list[str]]:
+        """Return supported FFmpeg demuxer/muxer formats with caching."""
+
+        with self._cache_lock:
+            if self._cached_formats is not None:
+                cached_at, payload = self._cached_formats
+                if time.monotonic() - cached_at < _CACHE_TTL_SECONDS:
+                    return {key: value.copy() for key, value in payload.items()}
+
+        formats = self._probe_formats()
+        with self._cache_lock:
+            self._cached_formats = (time.monotonic(), formats)
+        return {key: value.copy() for key, value in formats.items()}
+
+    def _probe_formats(self) -> dict[str, list[str]]:
+        try:
+            completed = subprocess.run(
+                ["ffmpeg", "-hide_banner", "-formats"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError as exc:  # pragma: no cover - depends on environment
+            raise FfmpegServiceError(
+                "FFmpeg is not installed or not available on the PATH."
+            ) from exc
+        except subprocess.CalledProcessError as exc:  # pragma: no cover - hard to trigger
+            stderr = (exc.stderr or exc.stdout or "").strip()
+            message = stderr or "Unable to query FFmpeg formats."
+            raise FfmpegServiceError(message) from exc
+
+        demuxers: set[str] = set()
+        muxers: set[str] = set()
+
+        for raw_line in completed.stdout.splitlines():
+            match = FORMAT_LINE_PATTERN.match(raw_line)
+            if not match:
+                continue
+
+            demux_flag, mux_flag, names = match.groups()
+            for candidate in self._split_format_names(names):
+                if demux_flag == "D":
+                    demuxers.add(candidate)
+                if mux_flag == "E":
+                    muxers.add(candidate)
+
+        return {
+            "inputs": sorted(demuxers),
+            "outputs": sorted(muxers),
+            "common": sorted(demuxers & muxers),
+        }
+
+    @staticmethod
+    def _split_format_names(value: str) -> Iterable[str]:
+        for item in value.split(","):
+            cleaned = item.strip().lower()
+            if cleaned:
+                yield cleaned
+
+    def convert_upload(
+        self,
+        upload: UploadFile,
+        *,
+        source_format: str | None,
+        target_format: str,
+    ) -> ConversionResult:
+        if not target_format:
+            raise FfmpegServiceError("target_format is required")
+
+        available = self.list_formats()
+        normalised_target = self._normalise_format(target_format)
+        if normalised_target not in {fmt.lower() for fmt in available["outputs"]}:
+            raise FfmpegServiceError(
+                f"FFmpeg does not support exporting to '{target_format}'."
+            )
+
+        normalised_source = None
+        if source_format:
+            normalised_source = self._normalise_format(source_format)
+            if normalised_source not in {fmt.lower() for fmt in available["inputs"]}:
+                raise FfmpegServiceError(
+                    f"FFmpeg cannot ingest files tagged as '{source_format}'."
+                )
+
+        workdir = Path(tempfile.mkdtemp(prefix="ffmpeg-convert-"))
+        input_path = self._write_upload(upload, workdir, normalised_source)
+        output_filename = self._build_output_filename(upload.filename, normalised_target)
+        output_path = workdir / output_filename
+
+        command = [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+        ]
+        if normalised_source:
+            command.extend(["-f", normalised_source])
+        command.extend(["-i", str(input_path), str(output_path)])
+
+        try:
+            subprocess.run(command, check=True)
+        except FileNotFoundError as exc:  # pragma: no cover - depends on environment
+            raise FfmpegServiceError(
+                "FFmpeg is not installed or not available on the PATH."
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or exc.stdout or "").strip()
+            message = stderr or "FFmpeg failed to convert the media file."
+            raise FfmpegServiceError(message) from exc
+
+        if not output_path.exists():  # pragma: no cover - defensive
+            raise FfmpegServiceError("FFmpeg reported success but no output file was created.")
+
+        mime_type, _ = mimetypes.guess_type(output_filename)
+        media_type = mime_type or "application/octet-stream"
+        return ConversionResult(output_path=output_path, filename=output_filename, media_type=media_type, workdir=workdir)
+
+    def cleanup_directory(self, directory: Path | str | None) -> None:
+        if not directory:
+            return
+        try:
+            shutil.rmtree(directory, ignore_errors=True)
+        except OSError:  # pragma: no cover - ignore cleanup errors
+            pass
+
+    @staticmethod
+    def _normalise_format(value: str) -> str:
+        cleaned = value.strip().lower().lstrip(".")
+        if not cleaned:
+            raise FfmpegServiceError("Format names must contain letters or numbers.")
+        if not re.fullmatch(r"[a-z0-9_]+", cleaned):
+            raise FfmpegServiceError(
+                "Format names may only include letters, numbers, or underscores."
+            )
+        return cleaned
+
+    @staticmethod
+    def _write_upload(upload: UploadFile, workdir: Path, source_format: str | None) -> Path:
+        stem = "source"
+        suffix = ""
+        if upload.filename:
+            original = Path(upload.filename)
+            if original.suffix:
+                suffix = original.suffix
+            else:
+                stem = original.stem or stem
+        if not suffix and source_format:
+            suffix = f".{source_format}"
+        if not suffix:
+            suffix = ".bin"
+
+        destination = workdir / f"{stem}{suffix}"
+        upload.file.seek(0)
+        with destination.open("wb") as buffer:
+            shutil.copyfileobj(upload.file, buffer)
+        return destination
+
+    @staticmethod
+    def _build_output_filename(original_name: str | None, target_format: str) -> str:
+        candidate = "converted"
+        if original_name:
+            stem = Path(original_name).stem.strip()
+            if stem:
+                candidate = stem
+        return f"{candidate}.{target_format}"
+
+
+ffmpeg_service = FfmpegService()

--- a/tools-api/app/templates/studio.html
+++ b/tools-api/app/templates/studio.html
@@ -484,6 +484,30 @@
                     <p>Inspect or download media via yt-dlp without touching the command line.</p>
                 </header>
                 <div class="panel__body grid two-column">
+                    <div class="card">
+                        <form id="ffmpeg-convert-form" class="tool-form">
+                            <div class="form-header">
+                                <h3>FFmpeg Converter</h3>
+                                <p class="muted">Upload any supported media, choose input and output formats, and we will transcode it with FFmpeg.</p>
+                            </div>
+                            <label for="ffmpeg-from-format">From</label>
+                            <select id="ffmpeg-from-format">
+                                <option value="">Auto detect</option>
+                            </select>
+                            <label for="ffmpeg-to-format">To</label>
+                            <select id="ffmpeg-to-format" required></select>
+                            <label for="ffmpeg-file">Media file</label>
+                            <input id="ffmpeg-file" type="file" required />
+                            <p id="ffmpeg-format-status" class="helper-text">Loading FFmpeg formats…</p>
+                            <div class="form-actions">
+                                <button type="button" class="text-btn" id="ffmpeg-refresh-formats">Refresh formats</button>
+                                <button type="submit" class="primary-btn">Convert</button>
+                            </div>
+                        </form>
+                    </div>
+                    <div class="card">
+                        <div id="ffmpeg-results" class="result-panel" aria-live="polite"></div>
+                    </div>
                     <div class="card span-two">
                         <form id="yt-dlp-form" class="tool-form">
                             <div class="form-header">

--- a/tools-api/tests/test_ffmpeg.py
+++ b/tools-api/tests/test_ffmpeg.py
@@ -1,0 +1,88 @@
+import io
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.routers.ffmpeg as ffmpeg_router
+from app.main import app
+from app.services.ffmpeg_service import ConversionResult, FfmpegServiceError
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_list_formats_returns_data(monkeypatch, client):
+    def fake_list_formats():
+        return {"inputs": ["wav"], "outputs": ["mp3"], "common": ["wav"]}
+
+    monkeypatch.setattr(ffmpeg_router.ffmpeg_service, "list_formats", fake_list_formats)
+
+    response = client.get("/media/ffmpeg/formats")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["inputs"] == ["wav"]
+    assert payload["outputs"] == ["mp3"]
+    assert payload["common"] == ["wav"]
+
+
+def test_list_formats_failure(monkeypatch, client):
+    def fake_list_formats():
+        raise FfmpegServiceError("ffmpeg unavailable")
+
+    monkeypatch.setattr(ffmpeg_router.ffmpeg_service, "list_formats", fake_list_formats)
+
+    response = client.get("/media/ffmpeg/formats")
+    assert response.status_code == 503
+    assert response.json()["detail"] == "ffmpeg unavailable"
+
+
+def test_convert_media_returns_file(monkeypatch, client, tmp_path):
+    output_path = tmp_path / "converted.mp3"
+    output_path.write_bytes(b"audio")
+    result = ConversionResult(
+        output_path=output_path,
+        filename="converted.mp3",
+        media_type="audio/mpeg",
+        workdir=tmp_path,
+    )
+
+    monkeypatch.setattr(ffmpeg_router.ffmpeg_service, "convert_upload", lambda *args, **kwargs: result)
+
+    cleaned = {}
+
+    def fake_cleanup(directory: Path | str | None):
+        cleaned["path"] = directory
+
+    monkeypatch.setattr(ffmpeg_router.ffmpeg_service, "cleanup_directory", fake_cleanup)
+
+    files = {"file": ("demo.wav", io.BytesIO(b"data"), "audio/wav")}
+    response = client.post(
+        "/media/ffmpeg/convert",
+        data={"source_format": "wav", "target_format": "mp3"},
+        files=files,
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "audio/mpeg"
+    assert response.content == b"audio"
+    assert cleaned["path"] == tmp_path
+
+
+def test_convert_media_failure(monkeypatch, client):
+    def fake_convert_upload(*args, **kwargs):
+        raise FfmpegServiceError("conversion failed")
+
+    monkeypatch.setattr(ffmpeg_router.ffmpeg_service, "convert_upload", fake_convert_upload)
+
+    files = {"file": ("demo.wav", io.BytesIO(b"data"), "audio/wav")}
+    response = client.post(
+        "/media/ffmpeg/convert",
+        data={"target_format": "mp3"},
+        files=files,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "conversion failed"


### PR DESCRIPTION
## Summary
- implement an ffmpeg service that enumerates supported formats and converts uploaded media
- expose `/media/ffmpeg/formats` and `/media/ffmpeg/convert` endpoints and register them with the FastAPI app
- add an FFmpeg converter card to the studio UI with format discovery and download handling, plus unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3dbe9bbf48328b3c0438334057e3c